### PR TITLE
Fixed a potential buffer overflow in xmpp_stanza_to_text when the stanza...

### DIFF
--- a/src/stanza.c
+++ b/src/stanza.c
@@ -398,7 +398,7 @@ int  xmpp_stanza_to_text(xmpp_stanza_t *stanza,
 	return XMPP_EMEM;
     }
 
-    ret = _render_stanza_recursive(stanza, buffer, length);
+    ret = _render_stanza_recursive(stanza, buffer, length - 1);
     if (ret < 0) return ret;
 
     if (ret > length - 1) {


### PR DESCRIPTION
Fixed a potential buffer overflow in xmpp_stanza_to_text when the stanza length was greater than the default buffer size of 1024. This occurred on Windows.
