### PR TITLE
Updates to rpm/libstrophe.spec

### DIFF
--- a/rpm/libstrophe.spec
+++ b/rpm/libstrophe.spec
@@ -8,11 +8,22 @@ License:	MIT/GPLv3
 URL:		http://strophe.im/libstrophe/
 Source0:	libstrophe_git.tar.gz
 
+BuildRequires:	automake
+BuildRequires:	openssl-devel
 BuildRequires:	expat-devel
-Requires:		expat
+Requires:	expat
 
 %description
 XMPP library in C
+
+%package        devel
+Summary:        Headers and libraries for building apps that use libstrophe
+Group:          Development/Libraries
+Requires:       %{name} = %{version}-%{release}
+
+%description    devel
+This package contains headers and libraries required to build applications that
+use the strophe XMPP library.
 
 %prep
 %setup -n libstrophe
@@ -25,8 +36,18 @@ make %{?_smp_mflags}
 %install
 make install DESTDIR=%{buildroot}
 
+%post -p /sbin/ldconfig
+
+%postun -p /sbin/ldconfig
+
 %files
+%defattr(-,root,root,-)
 %{_libdir}/libstrophe.a
+%doc
+
+%files devel
+%defattr(-,root,root,-)
 %{_includedir}/strophe.h
+%doc
 
 %changelog


### PR DESCRIPTION
To build the profanity IM client, I had to make a proper `-devel` package for strophe. In the process, I also explicitly listed out the requirements. Without them, I received the following while building on Fedora 19:

```
[kwhite@li356-23 ~]$ rpmbuild -bb ~/rpmbuild/SPECS/libstrophe.spec
Executing(%prep): /bin/sh -e /var/tmp/rpm-tmp.VccYgW
+ umask 022
+ cd /home/kwhite/rpmbuild/BUILD
+ cd /home/kwhite/rpmbuild/BUILD
+ rm -rf libstrophe
+ /usr/bin/gzip -dc /home/kwhite/rpmbuild/SOURCES/libstrophe_git.tar.gz
+ /usr/bin/tar -xvvf -
drwxrwxr-x kwhite/kwhite     0 2013-11-18 17:25 libstrophe/
drwxrwxr-x kwhite/kwhite     0 2013-11-18 17:25 libstrophe/src/
# ....
+ STATUS=0
+ '[' 0 -ne 0 ']'
+ cd libstrophe
+ /usr/bin/chmod -Rf a+rX,u+w,g-w,o-w .
+ ./bootstrap.sh
./bootstrap.sh: line 8: aclocal: command not found
./bootstrap.sh: line 9: automake: command not found
./bootstrap.sh: line 10: autoconf: command not found
error: Bad exit status from /var/tmp/rpm-tmp.VccYgW (%prep)


RPM build errors:
    Bad exit status from /var/tmp/rpm-tmp.VccYgW (%prep)
```
