### PR TITLE
configure.ac: fix misdetection of libxml2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -16,7 +16,7 @@ AC_ARG_WITH([libxml2],
 if test "x$with_libxml2" != xno; then
   PKG_CHECK_MODULES([libxml2], [libxml-2.0 >= 2.7],
                     [with_libxml2=yes], [dummy=1])
-  if test "x$with_libxml2" != yes; then
+  if test "x$with_libxml2" != xyes; then
     old_CFLAGS=$CFLAGS
     CFLAGS="-I /usr/include/libxml2"
     AC_CHECK_HEADER([libxml/parser.h],


### PR DESCRIPTION
A small typo in the detection of libxml2 leads to a successful
pkg-config discovery of libxml2 to be ignored. As a consequence,
configure.ac falls back to detecting the host libxml2, which does not
work in cross-compilation situation. This commit fixes this small
typo.

Signed-off-by: Thomas Petazzoni thomas.petazzoni@free-electrons.com
