### PR TITLE
Revert "Fixed a potential buffer overflow in xmpp_stanza_to_text when th...

### DIFF
--- a/src/stanza.c
+++ b/src/stanza.c
@@ -398,7 +398,7 @@ int  xmpp_stanza_to_text(xmpp_stanza_t *stanza,
 	return XMPP_EMEM;
     }
 
-    ret = _render_stanza_recursive(stanza, buffer, length - 1);
+    ret = _render_stanza_recursive(stanza, buffer, length);
     if (ret < 0) return ret;
 
     if (ret > length - 1) {


### PR DESCRIPTION
...e stanza length was greater than the default buffer size of 1024. Tested on Windows only."

This reverts commit 4b194b98cfa25b6f1ce617b3f964657f53dd8414.

The above commit was causing an issue when using the libotr library.  The library sends internal messages for the OTR protocol.  With the above commit, I am seeing some messages with a malformed closing tag (missing the closing `>`:

```
<message>internal OTR message</message
```

And the messages are not being processed meaning the protocol fails. After reverting this change, messages get sent correctly.

Tested on Ubuntu 13.10.
