### PR TITLE
Correct the libtool file

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -13,7 +13,8 @@ STROPHE_LIBS = -lstrophe $(PARSER_LIBS) $(SSL_LIBS)
 ## Main build targets
 lib_LTLIBRARIES = libstrophe.la
 
-libstrophe_la_CFLAGS=$(SSL_LIBS) $(STROPHE_FLAGS) $(PARSER_CFLAGS)
+libstrophe_la_CFLAGS=$(STROPHE_FLAGS) $(PARSER_CFLAGS)
+libstrophe_la_LDFLAGS=$(SSL_LIBS) $(PARSER_LIBS)
 libstrophe_la_SOURCES = src/auth.c src/conn.c src/ctx.c \
 	src/event.c src/handler.c src/hash.c \
 	src/jid.c src/md5.c src/sasl.c src/sha1.c \


### PR DESCRIPTION
LDFLAGS needs to be set, or the final library produced won't have dependency on the parser(expat/libxml2).

Someone has fixed the issue on SSL linking(https://github.com/strophe/libstrophe/commit/ac886a156a44f6e454a15dc4f78dfe9531a9fe69), and the parser should be linked as well. Thus it will confuse the packager manager's dependency generator(At least RPM).

And, this commit also correct the usage of libtool file cflags and ldflags introduced from the commit mentioned above, as they are not the same terminology.
