### PR TITLE
Updated homebrew install instructions

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -46,10 +46,9 @@ check package.
 
 ### OS X (with Homebrew package manager)
 
-You can install the requirements with:
+You can install libstrophe with:
 
-    brew install expat
-    brew install check
+    brew install libstrophe
 
 ## Documentation
 


### PR DESCRIPTION
As of https://github.com/Homebrew/homebrew/commit/5efa7a6be49015e3b327da0a215b9b5d827a69fb and https://github.com/Homebrew/homebrew/commit/16dd36bffc5d8ab0b1b8fd8cd240097bca5fcf2e there is a homebrew formula for libswift (https://github.com/Homebrew/homebrew/pull/31420). Therefore the install documentation should be updated.
