### PR TITLE
fix bug leading to losing of hash entries in hash_iter_next

### DIFF
--- a/src/hash.c
+++ b/src/hash.c
@@ -250,12 +250,13 @@ const char * hash_iter_next(hash_iterator_t *iter)
 {
     hash_t *table = iter->table;
     hashentry_t *entry = iter->entry;
-    int i = iter->index + 1;
+    int i = iter->index;
 
     /* advance until we find the next entry */
     if (entry != NULL) entry = entry->next;
     if (entry == NULL) {
 	/* we're off the end of list, search for a new entry */
+    i++;
 	while (i < iter->table->length) {
 	    entry = table->entries[i];
 	    if (entry != NULL) {


### PR DESCRIPTION
Hello,

There is a bug in `hash_iter_next` function, which can lead to skipping of hash elements due to the index `i` becoming invalid under certain conditions. Please review the fix addressing the bug in this pull request. Please comment if you require further information.
