### PR TITLE
Added a syslog logger

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -86,6 +86,7 @@ else
 fi
 
 AC_CHECK_HEADERS([arpa/nameser_compat.h])
+AC_CHECK_HEADERS([syslog.h])
 
 
 m4_ifdef([PKG_INSTALLDIR], [PKG_INSTALLDIR],

--- a/src/ctx.c
+++ b/src/ctx.c
@@ -199,7 +199,7 @@ static xmpp_log_t xmpp_default_log = { NULL, NULL };
  *  @param area the area the log message is for
  *  @param msg the log message
  */
-void xmpp_syslog_logger(void ** const userdata,
+static void xmpp_syslog_logger(void ** const userdata,
 			 xmpp_log_level_t level,
 			 const char * const area,
 			 const char * const msg)

--- a/src/ctx.c
+++ b/src/ctx.c
@@ -249,7 +249,6 @@ xmpp_log_t *xmpp_get_syslog_logger( const char *ident )
 {
 #ifdef HAVE_SYSLOG_H
 	syslog(LOG_INFO, "libstrophe syslog logger started");
-	fprintf(stderr, "libstrophe logging to syslog\n");
 
 	if (_xmpp_syslog_ident)
 		free(_xmpp_syslog_ident);

--- a/strophe.h
+++ b/strophe.h
@@ -155,6 +155,9 @@ struct _xmpp_log_t {
 /* return a default logger filtering at a given level */
 xmpp_log_t *xmpp_get_default_logger(xmpp_log_level_t level);
 
+/* return a syslog logger with optional identifier string */
+xmpp_log_t *xmpp_get_syslog_logger( const char * ident);
+
 /* connection */
 
 /* opaque connection object */


### PR DESCRIPTION
I use libstrophe on a number of embedded linux devices, where syslog is used for generic logging. 
I've created a syslog logger for use in libstrophe, which I believe is of general interest. It has been tested for some days on our setup, only change prior to this pull request is the check for syslog.h, to make it compile on windows platforms (I have no windows machines, and is thus unable to test whether it actually compiles on it).
Feel free to use it as is, or if you have any comments, i'll be glad to look at it.
