### PR TITLE
Fix some issues with event handling loop

### DIFF
--- a/src/event.c
+++ b/src/event.c
@@ -218,7 +218,8 @@ void xmpp_run_once(xmpp_ctx_t *ctx, const unsigned long timeout)
 	    tls_read_bytes += tls_pending(conn->tls);
 	}
 	
-	if (conn->sock > max) max = conn->sock;
+	if (conn->state != XMPP_STATE_DISCONNECTED && conn->sock > max)
+	    max = conn->sock;
 
 	connitem = connitem->next;
     }

--- a/src/event.c
+++ b/src/event.c
@@ -37,11 +37,14 @@
 #ifndef _WIN32
 #include <sys/select.h>
 #include <errno.h>
+#include <unistd.h>
+#define _sleep(x) usleep(x*1000)
 #else
 #include <winsock2.h>
 #define ETIMEDOUT WSAETIMEDOUT
 #define ECONNRESET WSAECONNRESET
 #define ECONNABORTED WSAECONNABORTED
+#define _sleep(x) Sleep(x)
 #endif
 
 #include <strophe.h>
@@ -225,7 +228,13 @@ void xmpp_run_once(xmpp_ctx_t *ctx, const unsigned long timeout)
     }
 
     /* check for events */
-    ret = select(max + 1, &rfds,  &wfds, NULL, &tv);
+    if (max > 0)
+        ret = select(max + 1, &rfds,  &wfds, NULL, &tv);
+    else {
+        if (timeout > 0)
+            _sleep(timeout);
+        return;
+    }
 
     /* select errored */
     if (ret < 0) {


### PR DESCRIPTION
1. Fix incorrectly inflating max fd for disconnected sockets which are not set in the fd set passed to select. Not usually a problem, but sometimes max fd can end up very large (> 16,000,000) and cause select to return an error.
2. Error spam on Win32 (possibly other platforms) when calling xmpp_run_once on a context that does not currently have any open connections.