### PR TITLE
fix Makefile.am to respect openssl_CFLAGS

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -6,6 +6,7 @@ AM_CFLAGS = -g -Wall
 PARSER_CFLAGS=@PARSER_CFLAGS@
 PARSER_LIBS=@PARSER_LIBS@
 
+SSL_CFLAGS = @openssl_CFLAGS@
 SSL_LIBS = @openssl_LIBS@
 
 STROPHE_FLAGS = -I$(top_srcdir)
@@ -14,7 +15,7 @@ STROPHE_LIBS = libstrophe.la
 ## Main build targets
 lib_LTLIBRARIES = libstrophe.la
 
-libstrophe_la_CFLAGS = $(STROPHE_FLAGS) $(PARSER_CFLAGS)
+libstrophe_la_CFLAGS = $(SSL_CFLAGS) $(STROPHE_FLAGS) $(PARSER_CFLAGS)
 libstrophe_la_LDFLAGS = $(SSL_LIBS) $(PARSER_LIBS)
 # Export only public API
 libstrophe_la_LDFLAGS += -export-symbols-regex '^xmpp_'


### PR DESCRIPTION
works when openssl is not installed in the default path, e.g. cross-compiling.