### PR TITLE
Fix invalid write in dopr(...)

### DIFF
--- a/src/snprintf.c
+++ b/src/snprintf.c
@@ -397,7 +397,8 @@ static int dopr (char *buffer, size_t maxlen, const char *format, va_list args)
       break; /* some picky compilers need this */
     }
   }
-  if (buffer != NULL)
+  if (buffer != NULL &&
+      maxlen > 0)
   {
     if (currlen < maxlen - 1) 
       buffer[currlen] = '\0';


### PR DESCRIPTION
Fix an invalid write in dopr(...) that occures when maxlen == 0 and buffer != 0 since 0-1 > 0 using size_t.