### PR TITLE
Namespace SHA functions

### DIFF
--- a/src/auth.c
+++ b/src/auth.c
@@ -1187,10 +1187,10 @@ int _handle_component_auth(xmpp_conn_t * const conn)
     /* Feed the session id and passphrase to the algorithm.
      * We need to compute SHA1(session_id + passphrase)
      */
-    SHA1_Init(&mdctx);
-    SHA1_Update(&mdctx, (uint8_t*)conn->stream_id, strlen(conn->stream_id));
-    SHA1_Update(&mdctx, (uint8_t*)conn->pass, strlen(conn->pass));
-    SHA1_Final(&mdctx, md_value);
+    xmpp_SHA1_Init(&mdctx);
+    xmpp_SHA1_Update(&mdctx, (uint8_t*)conn->stream_id, strlen(conn->stream_id));
+    xmpp_SHA1_Update(&mdctx, (uint8_t*)conn->pass, strlen(conn->pass));
+    xmpp_SHA1_Final(&mdctx, md_value);
 
     digest = xmpp_alloc(conn->ctx, 2*sizeof(md_value)+1);
     if (digest) {

--- a/src/scram.c
+++ b/src/scram.c
@@ -37,9 +37,9 @@ static void SHA1(const uint8_t* data, size_t len,
                  uint8_t digest[SHA1_DIGEST_SIZE])
 {
     SHA1_CTX ctx;
-    SHA1_Init(&ctx);
-    SHA1_Update(&ctx, data, len);
-    SHA1_Final(&ctx, digest);
+    xmpp_SHA1_Init(&ctx);
+    xmpp_SHA1_Update(&ctx, data, len);
+    xmpp_SHA1_Final(&ctx, digest);
 }
 
 static void HMAC_SHA1(const uint8_t *key, size_t key_len,
@@ -66,15 +66,15 @@ static void HMAC_SHA1(const uint8_t *key, size_t key_len,
         key_opad[i] = key_pad[i] ^ opad;
     }
 
-    SHA1_Init(&ctx);
-    SHA1_Update(&ctx, key_ipad, BLOCK_SIZE);
-    SHA1_Update(&ctx, text, len);
-    SHA1_Final(&ctx, sha_digest);
+    xmpp_SHA1_Init(&ctx);
+    xmpp_SHA1_Update(&ctx, key_ipad, BLOCK_SIZE);
+    xmpp_SHA1_Update(&ctx, text, len);
+    xmpp_SHA1_Final(&ctx, sha_digest);
 
-    SHA1_Init(&ctx);
-    SHA1_Update(&ctx, key_opad, BLOCK_SIZE);
-    SHA1_Update(&ctx, sha_digest, SHA1_DIGEST_SIZE);
-    SHA1_Final(&ctx, digest);
+    xmpp_SHA1_Init(&ctx);
+    xmpp_SHA1_Update(&ctx, key_opad, BLOCK_SIZE);
+    xmpp_SHA1_Update(&ctx, sha_digest, SHA1_DIGEST_SIZE);
+    xmpp_SHA1_Final(&ctx, digest);
 }
 
 static void SCRAM_SHA1_Hi(const uint8_t *text, size_t len,

--- a/src/sha1.c
+++ b/src/sha1.c
@@ -202,7 +202,7 @@ static void SHA1_Transform(uint32_t state[5], const uint8_t buffer[64])
 
 
 /* SHA1Init - Initialize new context */
-void SHA1_Init(SHA1_CTX* context)
+void xmpp_SHA1_Init(SHA1_CTX* context)
 {
     /* SHA1 initialization constants */
     context->state[0] = 0x67452301;
@@ -215,7 +215,7 @@ void SHA1_Init(SHA1_CTX* context)
 
 
 /* Run your data through this. */
-void SHA1_Update(SHA1_CTX* context, const uint8_t* data, const size_t len)
+void xmpp_SHA1_Update(SHA1_CTX* context, const uint8_t* data, const size_t len)
 {
     size_t i, j;
 
@@ -244,7 +244,7 @@ void SHA1_Update(SHA1_CTX* context, const uint8_t* data, const size_t len)
 
 
 /* Add padding and return the message digest. */
-void SHA1_Final(SHA1_CTX* context, uint8_t digest[SHA1_DIGEST_SIZE])
+void xmpp_SHA1_Final(SHA1_CTX* context, uint8_t digest[SHA1_DIGEST_SIZE])
 {
     uint32_t i;
     uint8_t  finalcount[8];
@@ -253,11 +253,11 @@ void SHA1_Final(SHA1_CTX* context, uint8_t digest[SHA1_DIGEST_SIZE])
         finalcount[i] = (unsigned char)((context->count[(i >= 4 ? 0 : 1)]
          >> ((3-(i & 3)) * 8) ) & 255);  /* Endian independent */
     }
-    SHA1_Update(context, (uint8_t *)"\200", 1);
+    xmpp_SHA1_Update(context, (uint8_t *)"\200", 1);
     while ((context->count[0] & 504) != 448) {
-        SHA1_Update(context, (uint8_t *)"\0", 1);
+        xmpp_SHA1_Update(context, (uint8_t *)"\0", 1);
     }
-    SHA1_Update(context, finalcount, 8);  /* Should cause a SHA1_Transform() */
+    xmpp_SHA1_Update(context, finalcount, 8);  /* Should cause a SHA1_Transform() */
     for (i = 0; i < SHA1_DIGEST_SIZE; i++) {
         digest[i] = (uint8_t)
          ((context->state[i>>2] >> ((3-(i & 3)) * 8) ) & 255);
@@ -300,12 +300,12 @@ FILE* file;
             return(-1);
         }
     } 
-    SHA1_Init(&context);
+    xmpp_SHA1_Init(&context);
     while (!feof(file)) {  /* note: what if ferror(file) */
         i = fread(buffer, 1, 16384, file);
-        SHA1_Update(&context, buffer, i);
+        xmpp_SHA1_Update(&context, buffer, i);
     }
-    SHA1_Final(&context, digest);
+    xmpp_SHA1_Final(&context, digest);
     fclose(file);
     for (i = 0; i < SHA1_DIGEST_SIZE/4; i++) {
         for (j = 0; j < 4; j++) {
@@ -358,9 +358,9 @@ int main(int argc, char** argv)
     fprintf(stdout, "verifying SHA-1 implementation... ");
     
     for (k = 0; k < 2; k++){ 
-        SHA1_Init(&context);
-        SHA1_Update(&context, (uint8_t*)test_data[k], strlen(test_data[k]));
-        SHA1_Final(&context, digest);
+        xmpp_SHA1_Init(&context);
+        xmpp_SHA1_Update(&context, (uint8_t*)test_data[k], strlen(test_data[k]));
+        xmpp_SHA1_Final(&context, digest);
 	digest_to_hex(digest, output);
 
         if (strcmp(output, test_results[k])) {
@@ -372,10 +372,10 @@ int main(int argc, char** argv)
         }    
     }
     /* million 'a' vector we feed separately */
-    SHA1_Init(&context);
+    xmpp_SHA1_Init(&context);
     for (k = 0; k < 1000000; k++)
-        SHA1_Update(&context, (uint8_t*)"a", 1);
-    SHA1_Final(&context, digest);
+        xmpp_SHA1_Update(&context, (uint8_t*)"a", 1);
+    xmpp_SHA1_Final(&context, digest);
     digest_to_hex(digest, output);
     if (strcmp(output, test_results[2])) {
         fprintf(stdout, "FAIL\n");

--- a/src/sha1.h
+++ b/src/sha1.h
@@ -23,9 +23,9 @@ typedef struct {
 
 #define SHA1_DIGEST_SIZE 20
 
-void SHA1_Init(SHA1_CTX* context);
-void SHA1_Update(SHA1_CTX* context, const uint8_t* data, const size_t len);
-void SHA1_Final(SHA1_CTX* context, uint8_t digest[SHA1_DIGEST_SIZE]);
+void xmpp_SHA1_Init(SHA1_CTX* context);
+void xmpp_SHA1_Update(SHA1_CTX* context, const uint8_t* data, const size_t len);
+void xmpp_SHA1_Final(SHA1_CTX* context, uint8_t digest[SHA1_DIGEST_SIZE]);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Fix statically linking against libstrophe by renaming the internal SHA
functions:

https://github.com/strophe/libstrophe/issues/40

Although the same function names are used by libstrophe and OpenSSL,
the signatures and contexts of the SHA functions differ, resulting in
a segfault if the OpenSSL versions are substituted.