### PR TITLE
Implement more stanza helpers

### DIFF
--- a/examples/active.c
+++ b/examples/active.c
@@ -59,7 +59,7 @@ void conn_handler(xmpp_conn_t * const conn, const xmpp_conn_event_t status,
 	xmpp_stanza_set_name(iq, "iq");
 	xmpp_stanza_set_type(iq, "get");
 	xmpp_stanza_set_id(iq, "active1");
-	xmpp_stanza_set_attribute(iq, "to", "xxxxxxxxx.com");
+	xmpp_stanza_set_to(iq, "xxxxxxxxx.com");
 
 	query = xmpp_stanza_new(ctx);
 	xmpp_stanza_set_name(query, "query");

--- a/examples/bot.c
+++ b/examples/bot.c
@@ -28,14 +28,11 @@ int version_handler(xmpp_conn_t * const conn, xmpp_stanza_t * const stanza, void
 	xmpp_stanza_t *reply, *query, *name, *version, *text;
 	char *ns;
 	xmpp_ctx_t *ctx = (xmpp_ctx_t*)userdata;
-	printf("Received version request from %s\n", xmpp_stanza_get_attribute(stanza, "from"));
+	printf("Received version request from %s\n", xmpp_stanza_get_from(stanza));
 	
-	reply = xmpp_stanza_new(ctx);
-	xmpp_stanza_set_name(reply, "iq");
+	reply = xmpp_stanza_reply(stanza);
 	xmpp_stanza_set_type(reply, "result");
-	xmpp_stanza_set_id(reply, xmpp_stanza_get_id(stanza));
-	xmpp_stanza_set_attribute(reply, "to", xmpp_stanza_get_attribute(stanza, "from"));
-	
+
 	query = xmpp_stanza_new(ctx);
 	xmpp_stanza_set_name(query, "query");
     ns = xmpp_stanza_get_ns(xmpp_stanza_get_children(stanza));
@@ -74,17 +71,16 @@ int message_handler(xmpp_conn_t * const conn, xmpp_stanza_t * const stanza, void
 	xmpp_ctx_t *ctx = (xmpp_ctx_t*)userdata;
 	
 	if(!xmpp_stanza_get_child_by_name(stanza, "body")) return 1;
-	if(xmpp_stanza_get_attribute(stanza, "type") !=NULL && !strcmp(xmpp_stanza_get_attribute(stanza, "type"), "error")) return 1;
+	if(xmpp_stanza_get_type(stanza) !=NULL && !strcmp(xmpp_stanza_get_type(stanza), "error")) return 1;
 	
 	intext = xmpp_stanza_get_text(xmpp_stanza_get_child_by_name(stanza, "body"));
 	
-	printf("Incoming message from %s: %s\n", xmpp_stanza_get_attribute(stanza, "from"), intext);
+	printf("Incoming message from %s: %s\n", xmpp_stanza_get_from(stanza), intext);
 	
-	reply = xmpp_stanza_new(ctx);
-	xmpp_stanza_set_name(reply, "message");
-	xmpp_stanza_set_type(reply, xmpp_stanza_get_type(stanza)?xmpp_stanza_get_type(stanza):"chat");
-	xmpp_stanza_set_attribute(reply, "to", xmpp_stanza_get_attribute(stanza, "from"));
-	
+	reply = xmpp_stanza_reply(stanza);
+	if (xmpp_stanza_get_type(reply))
+	    xmpp_stanza_set_type(reply, "chat");
+
 	body = xmpp_stanza_new(ctx);
 	xmpp_stanza_set_name(body, "body");
 	

--- a/src/stanza.c
+++ b/src/stanza.c
@@ -1038,3 +1038,25 @@ char *xmpp_stanza_get_attribute(xmpp_stanza_t * const stanza,
 
     return hash_get(stanza->attributes, name);
 }
+
+/** Delete an attribute from a stanza.
+ *
+ *  @param stanza a Strophe stanza object
+ *  @param name a string containing attribute name
+ *
+ *  @return XMPP_EOK (0) on success or a number less than 0 on failure
+ *
+ *  @ingroup Stanza
+ */
+int xmpp_stanza_del_attribute(xmpp_stanza_t * const stanza,
+				const char * const name)
+{
+    if (stanza->type != XMPP_STANZA_TAG)
+	return -1;
+
+    if (!stanza->attributes)
+	return -1;
+
+    return hash_drop(stanza->attributes, name);
+}
+

--- a/src/stanza.c
+++ b/src/stanza.c
@@ -737,6 +737,48 @@ char *xmpp_stanza_get_type(xmpp_stanza_t * const stanza)
     return (char *)hash_get(stanza->attributes, "type");
 }
 
+/** Get the 'to' attribute of the stanza object.
+ *  This is a convenience function equivalent to:
+ *  xmpp_stanza_get_attribute(stanza, "to");
+ *
+ *  @param stanza a Strophe stanza object
+ *
+ *  @return a string with the 'to' attribute value
+ *
+ *  @ingroup Stanza
+ */
+char *xmpp_stanza_get_to(xmpp_stanza_t * const stanza)
+{
+    if (stanza->type != XMPP_STANZA_TAG)
+	return NULL;
+
+    if (!stanza->attributes)
+	return NULL;
+
+    return (char *)hash_get(stanza->attributes, "to");
+}
+
+/** Get the 'from' attribute of the stanza object.
+ *  This is a convenience function equivalent to:
+ *  xmpp_stanza_get_attribute(stanza, "from");
+ *
+ *  @param stanza a Strophe stanza object
+ *
+ *  @return a string with the 'from' attribute value
+ *
+ *  @ingroup Stanza
+ */
+char *xmpp_stanza_get_from(xmpp_stanza_t * const stanza)
+{
+    if (stanza->type != XMPP_STANZA_TAG)
+	return NULL;
+
+    if (!stanza->attributes)
+	return NULL;
+
+    return (char *)hash_get(stanza->attributes, "from");
+}
+
 /** Get the first child of stanza with name.
  *  This function searches all the immediate children of stanza for a child
  *  stanza that matches the name.  The first matching child is returned.
@@ -917,6 +959,42 @@ int xmpp_stanza_set_type(xmpp_stanza_t * const stanza,
 			 const char * const type)
 {
     return xmpp_stanza_set_attribute(stanza, "type", type);
+}
+
+/** Set the 'to' attribute of a stanza.
+ *
+ *  This is a convenience function for:
+ *  xmpp_stanza_set_attribute(stanza, 'to', to);
+ *
+ *  @param stanza a Strophe stanza object
+ *  @param to a string containing the 'to' value
+ *
+ *  @return XMPP_EOK (0) on success or a number less than 0 on failure
+ *
+ *  @ingroup Stanza
+ */
+int xmpp_stanza_set_to(xmpp_stanza_t * const stanza,
+		       const char * const to)
+{
+    return xmpp_stanza_set_attribute(stanza, "to", to);
+}
+
+/** Set the 'from' attribute of a stanza.
+ *
+ *  This is a convenience function for:
+ *  xmpp_stanza_set_attribute(stanza, 'from', from);
+ *
+ *  @param stanza a Strophe stanza object
+ *  @param from a string containing the 'from' value
+ *
+ *  @return XMPP_EOK (0) on success or a number less than 0 on failure
+ *
+ *  @ingroup Stanza
+ */
+int xmpp_stanza_set_from(xmpp_stanza_t * const stanza,
+		       const char * const from)
+{
+    return xmpp_stanza_set_attribute(stanza, "from", from);
 }
 
 /** Get an attribute from a stanza.

--- a/src/stanza.c
+++ b/src/stanza.c
@@ -1060,3 +1060,44 @@ int xmpp_stanza_del_attribute(xmpp_stanza_t * const stanza,
     return hash_drop(stanza->attributes, name);
 }
 
+/** Create a stanza object in reply to another.
+ *  This function makes a copy of a stanza object with the attribute “to” set
+ *  its original “from”.
+ *  The stanza will have a reference count of one, so the caller does not
+ *  need to clone it.
+ *
+ *  @param stanza a Strophe stanza object
+ *
+ *  @return a new Strophe stanza object
+ *
+ *  @ingroup Stanza
+ */
+xmpp_stanza_t *xmpp_stanza_reply(xmpp_stanza_t * const stanza)
+{
+    xmpp_stanza_t *copy;
+
+    copy = xmpp_stanza_new(stanza->ctx);
+    if (!copy) goto copy_error;
+
+    copy->type = stanza->type;
+
+    if (stanza->data) {
+	copy->data = xmpp_strdup(stanza->ctx, stanza->data);
+	if (!copy->data) goto copy_error;
+    }
+
+    if (stanza->attributes) {
+	if (_stanza_copy_attributes(copy, stanza) == -1)
+            goto copy_error;
+    }
+
+    xmpp_stanza_set_to(copy, xmpp_stanza_get_from(stanza));
+    xmpp_stanza_del_attribute(copy, "from");
+
+    return copy;
+
+copy_error:
+    /* release all the hitherto allocated memory */
+    if (copy) xmpp_stanza_release(copy);
+    return NULL;
+}

--- a/strophe.h
+++ b/strophe.h
@@ -310,6 +310,8 @@ xmpp_stanza_t *xmpp_stanza_get_child_by_ns(xmpp_stanza_t * const stanza,
 xmpp_stanza_t *xmpp_stanza_get_next(xmpp_stanza_t * const stanza);
 char *xmpp_stanza_get_attribute(xmpp_stanza_t * const stanza,
 				const char * const name);
+int xmpp_stanza_del_attribute(xmpp_stanza_t * const stanza,
+				const char * const name);
 char * xmpp_stanza_get_ns(xmpp_stanza_t * const stanza);
 /* concatenate all child text nodes.  this function
  * returns a string that must be freed by the caller */

--- a/strophe.h
+++ b/strophe.h
@@ -335,15 +335,16 @@ int xmpp_stanza_set_text_with_size(xmpp_stanza_t *stanza,
 /* common stanza helpers */
 char *xmpp_stanza_get_type(xmpp_stanza_t * const stanza);
 char *xmpp_stanza_get_id(xmpp_stanza_t * const stanza);
+char *xmpp_stanza_get_to(xmpp_stanza_t * const stanza);
+char *xmpp_stanza_get_from(xmpp_stanza_t * const stanza);
 int xmpp_stanza_set_id(xmpp_stanza_t * const stanza, 
 		       const char * const id);
 int xmpp_stanza_set_type(xmpp_stanza_t * const stanza, 
 			 const char * const type);
-
-/* unimplemented
-int xmpp_stanza_set_to();
-int xmpp_stanza_set_from();
-*/
+int xmpp_stanza_set_to(xmpp_stanza_t * const stanza,
+			 const char * const to);
+int xmpp_stanza_set_from(xmpp_stanza_t * const stanza,
+			 const char * const from);
 
 /* allocate and initialize a stanza in reply to another */
 /* unimplemented

--- a/strophe.h
+++ b/strophe.h
@@ -347,11 +347,7 @@ int xmpp_stanza_set_to(xmpp_stanza_t * const stanza,
 			 const char * const to);
 int xmpp_stanza_set_from(xmpp_stanza_t * const stanza,
 			 const char * const from);
-
-/* allocate and initialize a stanza in reply to another */
-/* unimplemented
-xmpp_stanza_t *xmpp_stanza_reply(const xmpp_stanza_t *stanza);
-*/
+xmpp_stanza_t *xmpp_stanza_reply(xmpp_stanza_t * const stanza);
 
 /* stanza subclasses */
 /* unimplemented


### PR DESCRIPTION
This PR adds the following functions:

- xmpp_stanza_get_to() ;
- xmpp_stanza_set_to() ;
- xmpp_stanza_get_from() ;
- xmpp_stanza_set_from() ;
- xmpp_stanza_reply() ;
- xmpp_stanza_del_attribute().

These functions mostly help to reduce the number of lines of code.