### PR TITLE
Missing prototypes

### DIFF
--- a/src/ctx.c
+++ b/src/ctx.c
@@ -136,6 +136,9 @@ static const xmpp_log_level_t _xmpp_default_logger_levels[] = {XMPP_LEVEL_DEBUG,
 							       XMPP_LEVEL_WARN,
 							       XMPP_LEVEL_ERROR};
 
+void xmpp_default_logger(void * const, const xmpp_log_level_t,
+    const char * const, const char * const);
+
 /** Log a message.
  *  The default logger writes to stderr.
  *

--- a/src/sasl.c
+++ b/src/sasl.c
@@ -507,7 +507,7 @@ char *base64_encode(xmpp_ctx_t *ctx,
     int clen;
     char *cbuf, *c;
     uint32_t word, hextet;
-    int i;
+    uint32_t i;
 
     clen = base64_encoded_len(ctx, len);
     cbuf = xmpp_alloc(ctx, clen + 1);
@@ -585,7 +585,7 @@ unsigned char *base64_decode(xmpp_ctx_t *ctx,
     int dlen;
     unsigned char *dbuf, *d;
     uint32_t word, hextet;
-    int i;
+    uint32_t i;
 
     /* len must be a multiple of 4 */
     if (len & 0x03) return NULL;

--- a/src/sock.c
+++ b/src/sock.c
@@ -234,6 +234,25 @@ struct dnsquery_resourcerecord
 	struct dnsquery_srvrdata rdata;
 };
 
+void netbuf_add_32bitnum(unsigned char *, int, int *, unsigned int);
+void netbuf_add_16bitnum(unsigned char *, int, int *, unsigned short);
+void netbuf_get_32bitnum(unsigned char *, int, int *, unsigned int *);
+void netbuf_get_16bitnum(unsigned char *, int, int *, unsigned short *);
+void netbuf_add_domain_name(unsigned char *, int, int *, char *);
+int calc_domain_name_size(unsigned char *, int, int);
+int netbuf_get_domain_name(unsigned char *, int, int *, char *, int);
+void netbuf_add_dnsquery_header(unsigned char *, int, int *, \
+    struct dnsquery_header *);
+void netbuf_get_dnsquery_header(unsigned char *, int, int *, \
+    struct dnsquery_header *);
+void netbuf_add_dnsquery_question(unsigned char *, int, int *, \
+    struct dnsquery_question *);
+void netbuf_get_dnsquery_question(unsigned char *, int, int *, \
+    struct dnsquery_question *);
+void netbuf_get_dnsquery_srvrdata(unsigned char *, int, int *, \
+    struct dnsquery_srvrdata *);
+void netbuf_get_dnsquery_resourcerecord(unsigned char *, int, int *,
+    struct dnsquery_resourcerecord *);
 
 void netbuf_add_32bitnum(unsigned char *buf, int buflen, int *offset, unsigned int num)
 {

--- a/strophe.h
+++ b/strophe.h
@@ -310,6 +310,9 @@ xmpp_stanza_t *xmpp_stanza_get_child_by_ns(xmpp_stanza_t * const stanza,
 xmpp_stanza_t *xmpp_stanza_get_next(xmpp_stanza_t * const stanza);
 char *xmpp_stanza_get_attribute(xmpp_stanza_t * const stanza,
 				const char * const name);
+int xmpp_stanza_get_attribute_count(xmpp_stanza_t * const stanza);
+int xmpp_stanza_get_attributes(xmpp_stanza_t * const stanza,
+			       const char **attr, int attrlen);
 char * xmpp_stanza_get_ns(xmpp_stanza_t * const stanza);
 /* concatenate all child text nodes.  this function
  * returns a string that must be freed by the caller */


### PR DESCRIPTION
This PR fixes some compiler warnings: missing prototypes and signed versus unsigned comparison. The only important part is the two missing prototypes of public functions from strophe.h.

What do you think ?