### PR TITLE
snprintf.c clean up

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -28,6 +28,7 @@
 #include "util.h"
 #include "parser.h"
 #include "rand.h"
+#include "snprintf.h"
 
 /** run-time context **/
 
@@ -265,9 +266,5 @@ void disconnect_mem_error(xmpp_conn_t * const conn);
 /* auth functions */
 void auth_handle_open(xmpp_conn_t * const conn);
 void auth_handle_component_open(xmpp_conn_t * const conn);
-
-/* replacement snprintf and vsnprintf */
-int xmpp_snprintf (char *str, size_t count, const char *fmt, ...);
-int xmpp_vsnprintf (char *str, size_t count, const char *fmt, va_list arg);
 
 #endif /* __LIBSTROPHE_COMMON_H__ */

--- a/src/snprintf.c
+++ b/src/snprintf.c
@@ -71,7 +71,6 @@
 #include <stdarg.h>
 #define VA_LOCAL_DECL   va_list ap
 #define VA_START(f)     va_start(ap, f)
-#define VA_SHIFT(v,t)  ;   /* no-op for ANSI */
 #define VA_END          va_end(ap)
 
 #ifndef HAVE_VSNPRINTF
@@ -720,9 +719,6 @@ int xmpp_snprintf (char *str,size_t count,const char *fmt,...)
   int total;
     
   VA_START (fmt);
-  VA_SHIFT (str, char *);
-  VA_SHIFT (count, size_t );
-  VA_SHIFT (fmt, char *);
   total = xmpp_vsnprintf(str, count, fmt, ap);
   VA_END;
   return total;

--- a/src/snprintf.c
+++ b/src/snprintf.c
@@ -68,31 +68,17 @@
 
 /* Define this as a fall through, HAVE_STDARG_H is probably already set */
 
-#define HAVE_VARARGS_H
 #define HAVE_STDARG_H /* JAM: set always */
 
 
 /* varargs declarations: */
 
-#if defined(HAVE_STDARG_H)
-# include <stdarg.h>
-# define HAVE_STDARGS    /* let's hope that works everywhere (mj) */
-# define VA_LOCAL_DECL   va_list ap
-# define VA_START(f)     va_start(ap, f)
-# define VA_SHIFT(v,t)  ;   /* no-op for ANSI */
-# define VA_END          va_end(ap)
-#else
-# if defined(HAVE_VARARGS_H)
-#  include <varargs.h>
-#  undef HAVE_STDARGS
-#  define VA_LOCAL_DECL   va_list ap
-#  define VA_START(f)     va_start(ap)      /* f is ignored! */
-#  define VA_SHIFT(v,t) v = va_arg(ap,t)
-#  define VA_END        va_end(ap)
-# else
-/*XX ** NO VARARGS ** XX*/
-# endif
-#endif
+#include <stdarg.h>
+#define HAVE_STDARGS    /* let's hope that works everywhere (mj) */
+#define VA_LOCAL_DECL   va_list ap
+#define VA_START(f)     va_start(ap, f)
+#define VA_SHIFT(v,t)  ;   /* no-op for ANSI */
+#define VA_END          va_end(ap)
 
 #ifndef HAVE_VSNPRINTF
 

--- a/src/snprintf.c
+++ b/src/snprintf.c
@@ -66,11 +66,6 @@
 
 #include "snprintf.h"
 
-/* Define this as a fall through, HAVE_STDARG_H is probably already set */
-
-#define HAVE_STDARG_H /* JAM: set always */
-
-
 /* varargs declarations: */
 
 #include <stdarg.h>

--- a/src/snprintf.c
+++ b/src/snprintf.c
@@ -66,12 +66,6 @@
 
 #include "snprintf.h"
 
-#if !defined(HAVE_SNPRINTF) || !defined(HAVE_VSNPRINTF)
-
-#include <string.h>
-#include <ctype.h>
-#include <sys/types.h>
-
 /* Define this as a fall through, HAVE_STDARG_H is probably already set */
 
 #define HAVE_VARARGS_H
@@ -99,6 +93,12 @@
 /*XX ** NO VARARGS ** XX*/
 # endif
 #endif
+
+#ifndef HAVE_VSNPRINTF
+
+#include <string.h>
+#include <ctype.h>
+#include <sys/types.h>
 
 #ifdef HAVE_LONG_DOUBLE
 #define LDOUBLE long double
@@ -724,7 +724,6 @@ static int dopr_outch (char *buffer, size_t *currlen, size_t maxlen, char c)
   return 1;
 }
 
-#ifndef HAVE_VSNPRINTF
 int xmpp_vsnprintf (char *str, size_t count, const char *fmt, va_list args)
 {
   if (str != NULL)
@@ -757,6 +756,4 @@ int xmpp_snprintf (va_alist) va_dcl
   VA_END;
   return total;
 }
-#endif /* !HAVE_SNPRINTF */
-
 #endif /* !HAVE_SNPRINTF */

--- a/src/snprintf.c
+++ b/src/snprintf.c
@@ -64,6 +64,8 @@
 /* JAM: changed declarations to xmpp_snprintf and xmpp_vsnprintf to
    avoid namespace collision. */
 
+#include "snprintf.h"
+
 #if !defined(HAVE_SNPRINTF) || !defined(HAVE_VSNPRINTF)
 
 #include <string.h>
@@ -103,9 +105,6 @@
 #else
 #define LDOUBLE double
 #endif
-
-int xmpp_snprintf (char *str, size_t count, const char *fmt, ...);
-int xmpp_vsnprintf (char *str, size_t count, const char *fmt, va_list arg);
 
 static int dopr (char *buffer, size_t maxlen, const char *format, 
                  va_list args);

--- a/src/snprintf.c
+++ b/src/snprintf.c
@@ -69,7 +69,6 @@
 /* varargs declarations: */
 
 #include <stdarg.h>
-#define HAVE_STDARGS    /* let's hope that works everywhere (mj) */
 #define VA_LOCAL_DECL   va_list ap
 #define VA_START(f)     va_start(ap, f)
 #define VA_SHIFT(v,t)  ;   /* no-op for ANSI */
@@ -715,17 +714,8 @@ int xmpp_vsnprintf (char *str, size_t count, const char *fmt, va_list args)
 
 #ifndef HAVE_SNPRINTF
 /* VARARGS3 */
-#ifdef HAVE_STDARGS
 int xmpp_snprintf (char *str,size_t count,const char *fmt,...)
-#else
-int xmpp_snprintf (va_alist) va_dcl
-#endif
 {
-#ifndef HAVE_STDARGS
-  char *str;
-  size_t count;
-  char *fmt;
-#endif
   VA_LOCAL_DECL;
   int total;
     

--- a/src/snprintf.h
+++ b/src/snprintf.h
@@ -1,12 +1,8 @@
-/* snprintf.h
- * strophe XMPP client library -- stdarg wrappers
- *
- * Copyright (C) 2015 Dmitry Podgorny <pasis.ua@gmail.com>
- *
- *  This software is provided AS-IS with no warranty, either express or
- *  implied.
- *
- *  This program is dual licensed under the MIT and GPLv3 licenses.
+/*
+ * Copyright Patrick Powell 1995
+ * This code is based on code written by Patrick Powell (papowell@astart.com)
+ * It may be used for any purpose as long as this notice remains intact
+ * on all source code distributions
  */
 
 /** @file

--- a/src/snprintf.h
+++ b/src/snprintf.h
@@ -1,0 +1,38 @@
+/* snprintf.h
+ * strophe XMPP client library -- stdarg wrappers
+ *
+ * Copyright (C) 2015 Dmitry Podgorny <pasis.ua@gmail.com>
+ *
+ *  This software is provided AS-IS with no warranty, either express or
+ *  implied.
+ *
+ *  This program is dual licensed under the MIT and GPLv3 licenses.
+ */
+
+/** @file
+ *  Compatibility wrappers for OSes lacking snprintf(3) and/or vsnprintf(3).
+ */
+
+#ifndef __LIBSTROPHE_SNPRINTF_H__
+#define __LIBSTROPHE_SNPRINTF_H__
+
+#include <stddef.h>
+#include <stdarg.h>
+
+#if defined(HAVE_SNPRINTF) || defined(HAVE_VSNPRINTF)
+#include <stdio.h>
+#endif
+
+#ifdef HAVE_SNPRINTF
+#define xmpp_snprintf snprintf
+#else
+int xmpp_snprintf(char *str, size_t count, const char *fmt, ...);
+#endif
+
+#ifdef HAVE_VSNPRINTF
+#define xmpp_vsnprintf vsnprintf
+#else
+int xmpp_vsnprintf(char *str, size_t count, const char *fmt, va_list arg);
+#endif
+
+#endif /* __LIBSTROPHE_SNPRINTF_H__ */


### PR DESCRIPTION
Without this patch, compiling libstrophe with either HAVE_SNPRINTF or HAVE_VSNPRINTF will create a version of libstrophe without symbols for xmpp_snprintf() and xmpp_vsnprintf(). This will later create failure at linking time.

Now these two functions are always defined. The behavior of xmpp_vsnprintf() still depends on HAVE_VSNPRINTF though: if it is present it will fall-back to the vsnprintf() from libc, but otherwise it will export and use dopr().

As a side-effect it removes the useless conditions and definitions for :
- HAVE_SNPRINTF ;
- HAVE_STDARGS ;
- HAVE_VARARGS_H ;
- HAVE_STDARG_H.

I tested this on OpenBSD 5.7 and Ubuntu 12, but without autotools/configure/etc.