### PR TITLE
Fix --without-libxml2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -25,8 +25,7 @@ PKG_CHECK_MODULES([check], [check >= 0.9.4], [], [AC_MSG_WARN([libcheck not foun
 
 AC_ARG_WITH([libxml2],
             [AS_HELP_STRING([--with-libxml2], [use libxml2 for XML parsing])],
-            [with_libxml2=check],
-            [with_libxml2=no])
+            [], [with_libxml2=no])
 
 if test "x$with_libxml2" != xno; then
   PKG_CHECK_MODULES([libxml2], [libxml-2.0 >= 2.7],


### PR DESCRIPTION
The arguments of AC_ARG_WITH are (package, help-string, [action-if-given], [action-if-not-given]).
  action-if-given takes effect when the flag is given in **either** form (--with or --without).
  The proper code for action-if-given would thus be with_libxml2=$withval, which is already the default.
  Thus leaving this argument empty is the proper course of action.