### PR TITLE
Expose jid

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -80,17 +80,6 @@ void xmpp_debug(const xmpp_ctx_t * const ctx,
 		const char * const fmt,
 		...);
 
-/** jid */
-/* these return new strings that must be xmpp_free()'d */
-char *xmpp_jid_new(xmpp_ctx_t *ctx, const char *node,
-                                    const char *domain,
-                                    const char *resource);
-char *xmpp_jid_bare(xmpp_ctx_t *ctx, const char *jid);
-char *xmpp_jid_node(xmpp_ctx_t *ctx, const char *jid);
-char *xmpp_jid_domain(xmpp_ctx_t *ctx, const char *jid);
-char *xmpp_jid_resource(xmpp_ctx_t *ctx, const char *jid);
-
-
 /** connection **/
 
 /* opaque connection object */

--- a/src/jid.c
+++ b/src/jid.c
@@ -56,7 +56,7 @@ char *xmpp_jid_new(xmpp_ctx_t *ctx, const char *node,
 	    result[nlen+dlen] = '/';
 	    memcpy(result+nlen+dlen+1, resource, rlen - 1);
 	}
-	result[nlen+dlen+rlen] = '\0';
+	result[len] = '\0';
     }
 
     return result;

--- a/strophe.h
+++ b/strophe.h
@@ -365,6 +365,16 @@ void xmpp_run_once(xmpp_ctx_t *ctx, const unsigned long  timeout);
 void xmpp_run(xmpp_ctx_t *ctx);
 void xmpp_stop(xmpp_ctx_t *ctx);
 
+/** jid **/
+/* these return new strings that must be xmpp_free()'d */
+char *xmpp_jid_new(xmpp_ctx_t *ctx, const char *node,
+                                    const char *domain,
+                                    const char *resource);
+char *xmpp_jid_bare(xmpp_ctx_t *ctx, const char *jid);
+char *xmpp_jid_node(xmpp_ctx_t *ctx, const char *jid);
+char *xmpp_jid_domain(xmpp_ctx_t *ctx, const char *jid);
+char *xmpp_jid_resource(xmpp_ctx_t *ctx, const char *jid);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
There is a bunch of functions to manipulate JIDs. They are useful enough to be publicly exposed, rather than having to re-implement them in every clients.