### PR TITLE
Fix behaviour of libstrophe on signed char arch

### DIFF
--- a/src/parser_expat.c
+++ b/src/parser_expat.c
@@ -23,8 +23,8 @@
 #include "common.h"
 #include "parser.h"
 
-/* ASCII FF is invalid UTF-8 and should never be present in well-formed XML */
-#define NAMESPACE_SEP ('\xFF')
+/* Use the Unit Separator to delimit namespace and name in our XML*/
+#define NAMESPACE_SEP ('\x1F')
 
 struct _parser_t {
     xmpp_ctx_t *ctx;


### PR DESCRIPTION
The use of 0xff as a separator for libexpat only works on arch where
char is defined as an unsigned char.  This is an unportable behaviour.

Before this patch this is what I experienced:

xmpp DEBUG sock_connect to im.bouledef.eu:5222 returned 3
xmpp DEBUG attempting to connect to im.bouledef.eu
xmpp DEBUG connection successful
conn DEBUG SENT: <?xml version="1.0"?><stream:stream to="bouledef.eu" xml:lang="en" version="1.0" xmlns="jabber:client" xmlns:stream="http://etherx.jabber.org/streams">
conn ERROR Server did not open valid stream.
xmpp DEBUG Closing socket.
DEBUG: disconnected
event DEBUG Stopping event loop.
xmpp DEBUG RECV: <http://etherx.jabber.org/streamsÿfeatures><urn:ietf:params:xml:ns:xmpp-tlsÿstarttls><urn:ietf:params:xml:ns:xmpp-tlsÿrequired/></urn:ietf:params:xml:ns:xmpp-tlsÿstarttls></http://etherx.jabber.org/streamsÿfeatures>
event DEBUG Event loop completed.
name = http://etherx.jabber.org/streamsÿstream

Another way of solving this is by enforcing the gcc flag -funsigned-char, but it would tie libstrophe to a particular compiler and build system.