### PR TITLE
Making bot.c compatible to C++

### DIFF
--- a/examples/bot.c
+++ b/examples/bot.c
@@ -84,7 +84,7 @@ int message_handler(xmpp_conn_t * const conn, xmpp_stanza_t * const stanza, void
 	body = xmpp_stanza_new(ctx);
 	xmpp_stanza_set_name(body, "body");
 	
-	replytext = malloc(strlen(" to you too!") + strlen(intext) + 1);
+	replytext = (char *) malloc(strlen(" to you too!") + strlen(intext) + 1);
 	strcpy(replytext, intext);
 	strcat(replytext, " to you too!");
 	xmpp_free(ctx, intext);


### PR DESCRIPTION
By this small type casting change, I am able to compile bot.c with both ``gcc`` as well as with ``g++``

I am now able to use bot.c in my c++ programs