### PR TITLE
Free send queue on connection release

### DIFF
--- a/src/conn.c
+++ b/src/conn.c
@@ -187,6 +187,7 @@ xmpp_conn_t *xmpp_conn_clone(xmpp_conn_t * const conn)
 int xmpp_conn_release(xmpp_conn_t * const conn)
 {
     xmpp_ctx_t *ctx;
+    xmpp_send_queue_t *sq, *tsq;
     xmpp_connlist_t *item, *prev;
     xmpp_handlist_t *hlitem, *thli;
     hash_iterator_t *iter;
@@ -267,6 +268,15 @@ int xmpp_conn_release(xmpp_conn_t * const conn)
         }
 
         parser_free(conn->parser);
+
+	/* free queued */
+	sq = conn->send_queue_head;
+	while (sq) {
+	    tsq = sq;
+	    sq = sq->next;
+	    xmpp_free(ctx, tsq->data);
+	    xmpp_free(ctx, tsq);
+	}
 
         if (conn->domain) xmpp_free(ctx, conn->domain);
         if (conn->jid) xmpp_free(ctx, conn->jid);

--- a/src/event.c
+++ b/src/event.c
@@ -123,6 +123,10 @@ void xmpp_run_once(xmpp_ctx_t *ctx, const unsigned long timeout)
 		if (ret < 0 && !tls_is_recoverable(tls_error(conn->tls))) {
 		    /* an error occured */
 		    conn->error = tls_error(conn->tls);
+		    if( conn->error == 5 )
+			xmpp_debug(ctx, "xmpp", "Unrecoverable TLS write error, syscall %s.", strerror(errno));
+		    else
+			xmpp_debug(ctx, "xmpp", "Unrecoverable TLS write error, %d.", conn->error);
 		    break;
 		} else if (ret < towrite) {
 		    /* not all data could be sent now */
@@ -303,8 +307,11 @@ void xmpp_run_once(xmpp_ctx_t *ctx, const unsigned long timeout)
 		    if (conn->tls) {
 			if (!tls_is_recoverable(tls_error(conn->tls)))
 			{
-			    xmpp_debug(ctx, "xmpp", "Unrecoverable TLS error, %d.", tls_error(conn->tls));
 			    conn->error = tls_error(conn->tls);
+			    if( conn->error == 5 )
+				xmpp_debug(ctx, "xmpp", "Unrecoverable TLS read error, syscall %s.", strerror(errno));
+			    else
+				xmpp_debug(ctx, "xmpp", "Unrecoverable TLS read error, %d.", conn->error);
 			    conn_disconnect(conn);
 			}
 		    } else {

--- a/src/sock.c
+++ b/src/sock.c
@@ -28,6 +28,7 @@
 #include <unistd.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
+#include <netinet/tcp.h>
 #include <netdb.h>
 #include <fcntl.h>
 #include <arpa/nameser.h>
@@ -78,7 +79,7 @@ sock_t sock_connect(const char * const host, const unsigned int port)
     sock_t sock;
     char service[6];
     struct addrinfo *res, *ainfo, hints;
-    int err;
+    int err, optval;
 
     xmpp_snprintf(service, 6, "%u", port);
 
@@ -98,6 +99,17 @@ sock_t sock_connect(const char * const host, const unsigned int port)
         sock = socket(ainfo->ai_family, ainfo->ai_socktype, ainfo->ai_protocol);
         if (sock < 0)
             continue;
+
+	/* turn on keepalive */
+	optval = 1;
+	setsockopt(sock, SOL_SOCKET, SO_KEEPALIVE, &optval, sizeof(optval));
+	optval = 3;
+	setsockopt(sock, SOL_TCP, TCP_KEEPCNT, &optval, sizeof(optval));
+	optval = 75;
+	setsockopt(sock, SOL_TCP, TCP_KEEPIDLE, &optval, sizeof(optval));
+	optval = 75;
+	setsockopt(sock, SOL_TCP, TCP_KEEPINTVL, &optval, sizeof(optval));
+
 
         err = sock_set_nonblocking(sock);
         if (err == 0) {


### PR DESCRIPTION
Some code to free connection send queue on connection release.
Queue can still have some items after write error in xmpp_run_once.

Also adding TCP keepalive setting, but that is just a proposal. May be there must be something like
xmpp_set_socket_keepalive() function.