### PR TITLE
Avoid trying to link against libresolv for Android

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -14,6 +14,7 @@ AS_CASE([$host_os],
     [netbsd*],     [PLATFORM="bsd"],
     [*nto*|*qnx*], [PLATFORM="qnx"],
     [*solaris*],   [PLATFORM="solaris"],
+    [*android*],   [PLATFORM="android"],
                    [PLATFORM="nix"])
 
 AC_ARG_WITH([libxml2],
@@ -90,6 +91,7 @@ AS_CASE([$PLATFORM],
     [bsd],     [RESOLV_LIBS=""],
     [qnx],     [RESOLV_LIBS="-lsocket"],
     [solaris], [RESOLV_LIBS="-lresolv -lsocket -lnsl"],
+    [android], [RESOLV_LIBS=""],
                [RESOLV_LIBS="-lresolv"])
 
 LIBS_TMP="${LIBS}"


### PR DESCRIPTION
Android does not have a separate libresolv library.

This patch, created by @Neo-Oli, has been used in [Termux](https://termux.com/) to build a libstrophe package.