### PR TITLE
Re-work some API's + some smaller fixes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3,6 +3,8 @@ AUTOMAKE_OPTIONS = subdir-objects
 ACLOCAL_AMFLAGS = -I m4
 AM_CFLAGS = -g -Wall
 
+GCC_CFLAGS=@GCC_CFLAGS@
+
 PARSER_CFLAGS=@PARSER_CFLAGS@
 PARSER_LIBS=@PARSER_LIBS@
 
@@ -17,7 +19,7 @@ STROPHE_LIBS = libstrophe.la
 ## Main build targets
 lib_LTLIBRARIES = libstrophe.la
 
-libstrophe_la_CFLAGS = $(SSL_CFLAGS) $(STROPHE_FLAGS) $(PARSER_CFLAGS)
+libstrophe_la_CFLAGS = $(SSL_CFLAGS) $(STROPHE_FLAGS) $(PARSER_CFLAGS) $(GCC_CFLAGS)
 libstrophe_la_LDFLAGS = $(SSL_LIBS) $(PARSER_LIBS) $(RESOLV_LIBS) -no-undefined
 # Export only public API
 libstrophe_la_LDFLAGS += -export-symbols-regex '^xmpp_'

--- a/Makefile.am
+++ b/Makefile.am
@@ -11,7 +11,7 @@ SSL_LIBS = @openssl_LIBS@
 
 RESOLV_LIBS = @RESOLV_LIBS@
 
-STROPHE_FLAGS = -I$(top_srcdir)
+STROPHE_FLAGS = -I$(top_srcdir) -Wall -Wextra -Werror -Wno-unused-parameter
 STROPHE_LIBS = libstrophe.la
 
 ## Main build targets

--- a/configure.ac
+++ b/configure.ac
@@ -117,6 +117,15 @@ m4_ifdef([PKG_INSTALLDIR], [PKG_INSTALLDIR],
         [], [with_pkgconfigdir='$(libdir)/pkgconfig'])
     AC_SUBST([pkgconfigdir], [${with_pkgconfigdir}])])
 
+if `$CC -v 2>&1 | grep 'gcc version' >/dev/null 2>&1`; then
+  case `$CC -dumpversion 2>/dev/null` in
+    [[0-3]].* | \
+    4.[[0-7]].*)
+      GCC_CFLAGS="$GCC_CFLAGS -Wno-type-limits"
+        ;;
+  esac
+fi
+
 AM_CONDITIONAL([PARSER_EXPAT], [test x$with_parser != xlibxml2])
 AM_CONDITIONAL([DISABLE_TLS], [test x$enable_tls = xno])
 
@@ -124,6 +133,7 @@ AC_SUBST([PC_REQUIRES], [${PC_REQUIRES}])
 AC_SUBST([PC_CFLAGS], [${PC_CFLAGS}])
 AC_SUBST([PC_LIBS], [${PC_LIBS}])
 
+AC_SUBST(GCC_CFLAGS)
 AC_SUBST(PARSER_CFLAGS)
 AC_SUBST(PARSER_LIBS)
 AC_SUBST(RESOLV_LIBS)

--- a/examples/vcard.c
+++ b/examples/vcard.c
@@ -131,7 +131,7 @@ static vcard_cb_t vcard_cb_get(xmpp_stanza_t *stanza)
 {
     vcard_cb_t cb = NULL;
     const char *tag;
-    int i;
+    size_t i;
 
     static struct {
         const char *tag;

--- a/src/common.h
+++ b/src/common.h
@@ -107,7 +107,7 @@ typedef struct _xmpp_handlist_t xmpp_handlist_t;
 struct _xmpp_handlist_t {
     /* common members */
     int user_handler;
-    void *handler;
+    int (*handler)();
     void *userdata;
     int enabled; /* handlers are added disabled and enabled after the
                   * handler chain is processed to prevent stanzas from

--- a/src/common.h
+++ b/src/common.h
@@ -50,6 +50,8 @@ struct _xmpp_ctx_t {
     xmpp_rand_t *rand;
     xmpp_loop_status_t loop_status;
     xmpp_connlist_t *connlist;
+
+    unsigned long timeout;
 };
 
 

--- a/src/ctx.c
+++ b/src/ctx.c
@@ -91,6 +91,14 @@ void xmpp_shutdown(void)
 #define LIBXMPP_VERSION_MINOR (0)
 #endif
 
+#ifndef DEFAULT_TIMEOUT
+/** @def DEFAULT_TIMEOUT
+ *  The default timeout in milliseconds for the event loop.
+ *  This is set to 1 millisecond.
+ */
+#define DEFAULT_TIMEOUT 1
+#endif
+
 /** Check that Strophe supports a specific API version.
  *
  *  @param major the major version number
@@ -410,6 +418,7 @@ xmpp_ctx_t *xmpp_ctx_new(const xmpp_mem_t * const mem,
         ctx->connlist = NULL;
         ctx->loop_status = XMPP_LOOP_NOTSTARTED;
         ctx->rand = xmpp_rand_new(ctx);
+        ctx->timeout = DEFAULT_TIMEOUT;
         if (ctx->rand == NULL) {
             xmpp_free(ctx, ctx);
             ctx = NULL;
@@ -430,5 +439,17 @@ void xmpp_ctx_free(xmpp_ctx_t * const ctx)
     /* mem and log are owned by their suppliers */
     xmpp_rand_free(ctx, ctx->rand);
     xmpp_free(ctx, ctx); /* pull the hole in after us */
+}
+
+/** Set the timeout to use when calling xmpp_run().
+ *
+ *  @param ctx a Strophe context object
+ *  @param timeout the time to wait for events in milliseconds
+ *
+ *  @ingroup Context
+ */
+void xmpp_ctx_set_timeout(xmpp_ctx_t * const ctx, const unsigned long timeout)
+{
+  ctx->timeout = timeout;
 }
 

--- a/src/event.c
+++ b/src/event.c
@@ -51,14 +51,6 @@
 #include "common.h"
 #include "parser.h"
 
-#ifndef DEFAULT_TIMEOUT
-/** @def DEFAULT_TIMEOUT
- *  The default timeout in milliseconds for the event loop.
- *  This is set to 1 millisecond.
- */
-#define DEFAULT_TIMEOUT 1
-#endif
-
 /** Run the event loop once.
  *  This function will run send any data that has been queued by
  *  xmpp_send and related functions and run through the Strophe even
@@ -333,7 +325,7 @@ void xmpp_run(xmpp_ctx_t *ctx)
 
     ctx->loop_status = XMPP_LOOP_RUNNING;
     while (ctx->loop_status == XMPP_LOOP_RUNNING) {
-        xmpp_run_once(ctx, DEFAULT_TIMEOUT);
+        xmpp_run_once(ctx, ctx->timeout);
     }
 
     /* make it possible to start event loop again */

--- a/src/handler.c
+++ b/src/handler.c
@@ -229,7 +229,7 @@ static void _timed_handler_add(xmpp_conn_t * const conn,
 
     /* check if handler is already in the list */
     for (item = conn->timed_handlers; item; item = item->next) {
-        if (item->handler == (void *)handler && item->userdata == userdata) {
+        if (item->handler == handler && item->userdata == userdata) {
             xmpp_warn(conn->ctx, "xmpp", "Timed handler already exists.");
             break;
         }
@@ -241,7 +241,7 @@ static void _timed_handler_add(xmpp_conn_t * const conn,
     if (!item) return;
 
     item->user_handler = user_handler;
-    item->handler = (void *)handler;
+    item->handler = handler;
     item->userdata = userdata;
     item->enabled = 0;
     item->next = NULL;
@@ -277,7 +277,7 @@ void xmpp_timed_handler_delete(xmpp_conn_t * const conn,
     prev = NULL;
     item = conn->timed_handlers;
     while (item) {
-        if (item->handler == (void *)handler) {
+        if (item->handler == handler) {
             if (prev)
                 prev->next = item->next;
             else
@@ -302,7 +302,7 @@ static void _id_handler_add(xmpp_conn_t * const conn,
     /* check if handler is already in the list */
     item = (xmpp_handlist_t *)hash_get(conn->id_handlers, id);
     while (item) {
-        if (item->handler == (void *)handler && item->userdata == userdata) {
+        if (item->handler == handler && item->userdata == userdata) {
             xmpp_warn(conn->ctx, "xmpp", "Id handler already exists.");
             break;
         }
@@ -315,7 +315,7 @@ static void _id_handler_add(xmpp_conn_t * const conn,
     if (!item) return;
 
     item->user_handler = user_handler;
-    item->handler = (void *)handler;
+    item->handler = handler;
     item->userdata = userdata;
     item->enabled = 0;
     item->next = NULL;
@@ -358,7 +358,7 @@ void xmpp_id_handler_delete(xmpp_conn_t * const conn,
     while (item) {
         next = item->next;
 
-        if (item->handler == (void *)handler) {
+        if (item->handler == handler) {
             if (prev)
                 prev->next = next;
             else {
@@ -390,7 +390,7 @@ static void _handler_add(xmpp_conn_t * const conn,
     for (item = conn->handlers; item; item = item->next) {
         /* same handler function can process different stanzas and
            distinguish them according to userdata. */
-        if (item->handler == (void *)handler && item->userdata == userdata) {
+        if (item->handler == handler && item->userdata == userdata) {
             xmpp_warn(conn->ctx, "xmpp", "Stanza handler already exists.");
             break;
         }
@@ -402,7 +402,7 @@ static void _handler_add(xmpp_conn_t * const conn,
     if (!item) return;
 
     item->user_handler = user_handler;
-    item->handler = (void *)handler;
+    item->handler = handler;
     item->userdata = userdata;
     item->enabled = 0;
     item->next = NULL;
@@ -462,7 +462,7 @@ void xmpp_handler_delete(xmpp_conn_t * const conn,
     prev = NULL;
     item = conn->handlers;
     while (item) {
-        if (item->handler == (void *)handler) {
+        if (item->handler == handler) {
             if (prev)
                 prev->next = item->next;
             else

--- a/src/stanza.c
+++ b/src/stanza.c
@@ -431,7 +431,7 @@ int xmpp_stanza_to_text(xmpp_stanza_t *stanza,
     ret = _render_stanza_recursive(stanza, buffer, length);
     if (ret < 0) return ret;
 
-    if (ret > length - 1) {
+    if ((size_t)ret > length - 1) {
 	tmp = xmpp_realloc(stanza->ctx, buffer, ret + 1);
 	if (!tmp) {
 	    xmpp_free(stanza->ctx, buffer);
@@ -443,7 +443,7 @@ int xmpp_stanza_to_text(xmpp_stanza_t *stanza,
 	buffer = tmp;
 
 	ret = _render_stanza_recursive(stanza, buffer, length);
-	if (ret > length - 1) return XMPP_EMEM;
+	if ((size_t)ret > length - 1) return XMPP_EMEM;
     }
     
     buffer[length - 1] = 0;

--- a/src/tls_openssl.c
+++ b/src/tls_openssl.c
@@ -57,6 +57,13 @@ void tls_initialize(void)
 
 void tls_shutdown(void)
 {
+    ERR_free_strings();
+    EVP_cleanup();
+    CRYPTO_cleanup_all_ex_data();
+#if OPENSSL_VERSION_NUMBER >= 0x10200000
+    SSL_COMP_free_compression_methods();
+#endif
+    ERR_remove_state(0);
     return;
 }
 

--- a/strophe.h
+++ b/strophe.h
@@ -117,6 +117,7 @@ typedef struct _xmpp_ctx_t xmpp_ctx_t;
 xmpp_ctx_t *xmpp_ctx_new(const xmpp_mem_t * const mem, 
 			 const xmpp_log_t * const log);
 void xmpp_ctx_free(xmpp_ctx_t * const ctx);
+void xmpp_ctx_set_timeout(xmpp_ctx_t * const ctx, const unsigned long timeout);
 
 /* free some blocks returned by other APIs, for example the
    buffer you get from xmpp_stanza_to_text */

--- a/tests/test_base64.c
+++ b/tests/test_base64.c
@@ -134,8 +134,7 @@ int main(int argc, char *argv[])
     unsigned char *udec;
     char *dec;
     char *enc;
-    size_t len;
-    int i;
+    size_t len, i;
 
     printf("BASE64 tests.\n");
 

--- a/tests/test_string.c
+++ b/tests/test_string.c
@@ -79,7 +79,7 @@ static int test_strdup_one(xmpp_ctx_t *ctx, const char *s)
 static int test_strdup(void)
 {
     xmpp_ctx_t *ctx;
-    int i;
+    size_t i;
     int rc = 0;
 
     static const char *tests[] = { "", "\0", "test", "s p a c e", "\n\r" };


### PR DESCRIPTION
While working with libstrophe I did the following changes that are worth to be upstream in my opinion

* Added `xmpp_ctx_set_timeout()`
* Fixed openssl memory leaks
* Fixed storage for function pointers
* Enable Warnings when compiling

I know this shouldn't be such a huge PR with that much different changes, sorry. If you want separate PR's for some of the things feel free to tell me and I'll split this up into multiple PR's.