### PR TITLE
Fix annoying comment about how disconnect can be performed

### DIFF
--- a/src/conn.c
+++ b/src/conn.c
@@ -713,7 +713,7 @@ void conn_parser_reset(xmpp_conn_t * const conn)
 /** Initiate termination of the connection to the XMPP server.
  *  This function starts the disconnection sequence by sending
  *  </stream:stream> to the XMPP server.  This function will do nothing
- *  if the connection state is CONNECTING or CONNECTED.
+ *  if the connection state is different from CONNECTING or CONNECTED.
  *
  *  @param conn a Strophe connection object
  *


### PR DESCRIPTION
As xmpp_disconnect function checks at start, a function will do nothing if connection state isn't CONNECTING or CONNECTED.