### PR TITLE
Add xmpp_stanza_get_child_by_name_and_ns()

### DIFF
--- a/src/stanza.c
+++ b/src/stanza.c
@@ -835,6 +835,40 @@ xmpp_stanza_t *xmpp_stanza_get_child_by_ns(xmpp_stanza_t * const stanza,
     return child;
 }
 
+/** Get the first child of stanza with name and a given namespace.
+ *  This function searches all the immediate children of stanza for a child
+ *  stanza that matches the name and namespace provided.
+ *  The first matching child is returned.
+ *  
+ *  @param stanza a Strophe stanza object
+ *  @param name a string with the name to match
+ *  @param ns a string with the namespace to match
+ *
+ *  @return the matching child stanza object or NULL if no match was found
+ *
+ *  @ingroup Stanza
+ */
+xmpp_stanza_t *xmpp_stanza_get_child_by_name_and_ns(xmpp_stanza_t * const stanza, 
+                                             const char * const name,
+                                             const char * const ns)
+{
+    xmpp_stanza_t *child;
+    const char *child_ns;
+    const char *child_name;
+
+    for (child = stanza->children; child; child = child->next) {
+        child_name = xmpp_stanza_get_name(child);
+        if (child_name && strcmp(name, child_name) == 0) {
+            child_ns = xmpp_stanza_get_ns(child);
+            if (child_ns && strcmp(ns, child_ns) == 0) {
+                break;
+            }
+        }
+    }
+
+    return child;
+}
+
 /** Get the list of children.
  *  This function returns the first child of the stanza object.  The rest
  *  of the children can be obtained by calling xmpp_stanza_get_next() to

--- a/src/stanza.c
+++ b/src/stanza.c
@@ -854,11 +854,10 @@ xmpp_stanza_t *xmpp_stanza_get_child_by_name_and_ns(xmpp_stanza_t * const stanza
 {
     xmpp_stanza_t *child;
     const char *child_ns;
-    const char *child_name;
 
     for (child = stanza->children; child; child = child->next) {
-        child_name = xmpp_stanza_get_name(child);
-        if (child_name && strcmp(name, child_name) == 0) {
+        if (child->type == XMPP_STANZA_TAG &&
+            (strcmp(name, xmpp_stanza_get_name(child)) == 0)) {
             child_ns = xmpp_stanza_get_ns(child);
             if (child_ns && strcmp(ns, child_ns) == 0) {
                 break;

--- a/strophe.h
+++ b/strophe.h
@@ -332,9 +332,12 @@ int xmpp_stanza_to_text(xmpp_stanza_t *stanza,
 
 xmpp_stanza_t *xmpp_stanza_get_children(xmpp_stanza_t * const stanza);
 xmpp_stanza_t *xmpp_stanza_get_child_by_name(xmpp_stanza_t * const stanza, 
-					     const char * const name);
+        const char * const name);
 xmpp_stanza_t *xmpp_stanza_get_child_by_ns(xmpp_stanza_t * const stanza,
-					   const char * const ns);
+        const char * const ns);
+xmpp_stanza_t *xmpp_stanza_get_child_by_name_and_ns(xmpp_stanza_t * const stanza, 
+        const char * const name,
+        const char * const ns);
 xmpp_stanza_t *xmpp_stanza_get_next(xmpp_stanza_t * const stanza);
 int xmpp_stanza_add_child(xmpp_stanza_t *stanza, xmpp_stanza_t *child);
 

--- a/strophe.h
+++ b/strophe.h
@@ -332,12 +332,12 @@ int xmpp_stanza_to_text(xmpp_stanza_t *stanza,
 
 xmpp_stanza_t *xmpp_stanza_get_children(xmpp_stanza_t * const stanza);
 xmpp_stanza_t *xmpp_stanza_get_child_by_name(xmpp_stanza_t * const stanza, 
-        const char * const name);
+                                             const char * const name);
 xmpp_stanza_t *xmpp_stanza_get_child_by_ns(xmpp_stanza_t * const stanza,
-        const char * const ns);
+                                             const char * const ns);
 xmpp_stanza_t *xmpp_stanza_get_child_by_name_and_ns(xmpp_stanza_t * const stanza, 
-        const char * const name,
-        const char * const ns);
+                                             const char * const name,
+                                             const char * const ns);
 xmpp_stanza_t *xmpp_stanza_get_next(xmpp_stanza_t * const stanza);
 int xmpp_stanza_add_child(xmpp_stanza_t *stanza, xmpp_stanza_t *child);
 


### PR DESCRIPTION
I think it's fairly common in the XMPP world to actually want a stanza
by it's NS but also want a certain name.

For example this was needed in Profanity:
https://github.com/profanity-im/profanity/commit/68af0aad65d243e654866eac5a7cd728ee293aa0