### PR TITLE
Haiku port

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -11,7 +11,8 @@ SSL_LIBS = @openssl_LIBS@
 RESOLV_CFLAGS = @RESOLV_CFLAGS@
 RESOLV_LIBS = @RESOLV_LIBS@
 
-STROPHE_FLAGS = -I$(top_srcdir) -Wall -Wextra -Wno-unused-parameter
+WARNING_FLAGS = @WARNING_FLAGS@
+STROPHE_FLAGS = -I$(top_srcdir) $(WARNING_FLAGS)
 STROPHE_LIBS = libstrophe.la
 
 ## Main build targets

--- a/configure.ac
+++ b/configure.ac
@@ -15,6 +15,7 @@ AS_CASE([$host_os],
     [*nto*|*qnx*], [PLATFORM="qnx"],
     [*solaris*],   [PLATFORM="solaris"],
     [*android*],   [PLATFORM="android"],
+    [*haiku*],     [PLATFORM="haiku"],
                    [PLATFORM="nix"])
 
 AC_ARG_WITH([libxml2],
@@ -84,7 +85,7 @@ fi
 
 AC_MSG_NOTICE([libstrophe will use the $with_parser XML parser])
 
-AC_SEARCH_LIBS([socket], [socket])
+AC_SEARCH_LIBS([socket], [network socket])
 
 if test "x$enable_cares" = xyes; then
     PKG_CHECK_MODULES([libcares], [libcares >= 1.7.0],
@@ -103,6 +104,7 @@ AS_CASE([$PLATFORM],
     [qnx],     [RESOLV_LIBS="-lsocket"],
     [solaris], [RESOLV_LIBS="-lresolv -lsocket -lnsl"],
     [android], [RESOLV_LIBS=""],
+    [haiku],   [RESOLV_LIBS="-lnetwork"],
                [RESOLV_LIBS="-lresolv"])
 
 LIBS_TMP="${LIBS}"

--- a/configure.ac
+++ b/configure.ac
@@ -18,6 +18,12 @@ AS_CASE([$host_os],
     [*haiku*],     [PLATFORM="haiku"],
                    [PLATFORM="nix"])
 
+WARNING_FLAGS="-Wall"
+
+AS_CASE([$PLATFORM],
+    [haiku],   [],
+               [WARNING_FLAGS="$WARNING_FLAGS -Wextra -Wno-unused-parameter"])
+
 AC_ARG_WITH([libxml2],
     [AS_HELP_STRING([--with-libxml2], [use libxml2 for XML parsing, expat is the default])])
 AC_ARG_ENABLE([tls],
@@ -146,5 +152,6 @@ AC_SUBST(PARSER_CFLAGS)
 AC_SUBST(PARSER_LIBS)
 AC_SUBST(RESOLV_CFLAGS)
 AC_SUBST(RESOLV_LIBS)
+AC_SUBST(WARNING_FLAGS)
 AC_CONFIG_FILES([Makefile libstrophe.pc])
 AC_OUTPUT

--- a/src/ctx.c
+++ b/src/ctx.c
@@ -51,7 +51,7 @@
 #include "util.h"
 
 /* Workaround for visual studio without va_copy support. */
-#if defined(_MSC_VER) && _MSC_VER < 1800
+#if defined(_MSC_VER) && _MSC_VER < 1800 || defined(__HAIKU__)
 #define va_copy(d,s) ((d) = (s))
 #endif
 

--- a/src/tls_openssl.c
+++ b/src/tls_openssl.c
@@ -110,6 +110,10 @@ tls_t *tls_new(xmpp_conn_t *conn)
 
     if (tls) {
         int ret;
+#if OPENSSL_VERSION_NUMBER >= 0x10002000L
+        /* Hostname verification is supported in OpenSSL 1.0.2 and newer. */
+        X509_VERIFY_PARAM *param;
+#endif
         memset(tls, 0, sizeof(*tls));
 
         tls->ctx = conn->ctx;
@@ -139,7 +143,7 @@ tls_t *tls_new(xmpp_conn_t *conn)
         SSL_set_verify(tls->ssl, mode, 0);
 #if OPENSSL_VERSION_NUMBER >= 0x10002000L
         /* Hostname verification is supported in OpenSSL 1.0.2 and newer. */
-        X509_VERIFY_PARAM *param = SSL_get0_param(tls->ssl);
+        param = SSL_get0_param(tls->ssl);
 
         /*
          * Allow only complete wildcards.  RFC 6125 discourages wildcard usage


### PR DESCRIPTION
This fixes the build for Haiku:
- va_copy isn't yet available,
- we prefer to have C89 which allows to build for the primary arch, even though we have latest GCC as secondary arch,
- we have all of socket and resolver stuff in libnetwork and we want to avoid libsocket which is a compatibility lib for one of the BeOS network stacks,
- GCC 2.95 doesn't know some warning flags.