### PR TITLE
Enable TLS SNI

### DIFF
--- a/src/tls_openssl.c
+++ b/src/tls_openssl.c
@@ -153,7 +153,7 @@ tls_t *tls_new(xmpp_conn_t *conn)
         if (tls->ssl == NULL)
             goto err_free_ctx;
 
-#if OPENSSL_VERSION_NUMBER >= 0x10000000L
+#if OPENSSL_VERSION_NUMBER >= 0x0908060L && !defined(OPENSSL_NO_TLSEXT)
         /* Enable SNI. */
         SSL_set_tlsext_host_name(tls->ssl, conn->domain);
 #endif

--- a/src/tls_openssl.c
+++ b/src/tls_openssl.c
@@ -153,6 +153,11 @@ tls_t *tls_new(xmpp_conn_t *conn)
         if (tls->ssl == NULL)
             goto err_free_ctx;
 
+#if OPENSSL_VERSION_NUMBER >= 0x10000000L
+        /* Enable SNI. */
+        SSL_set_tlsext_host_name(tls->ssl, conn->domain);
+#endif
+
         /* Trust server's certificate when user sets the flag explicitly. */
         mode = conn->tls_trust ? SSL_VERIFY_NONE : SSL_VERIFY_PEER;
         SSL_set_verify(tls->ssl, mode, 0);


### PR DESCRIPTION
In STARTTLS mode, the server can use the domainpart contained in the 'to' attribute of the initial stream header to determine which certificate to present (RFC 6210, 5.4.3.1.4). However, in “legacy” SSL mode, TLS SNI is needed to convey this information to the server. It shouldn't hurt to always set it.

Background information: I'm using libstrophe to connect to Firebase Cloud Messaging XMPP servers. After switching to OpenSSL 1.1.1, this gave me certificate verification errors. Turns out that SNI is required by Google servers when connecting with TLSv1.3, or they will present a fake certificate (OU = "No SNI provided; please fix your client.", CN = invalid2.invalid).