### PR TITLE
Remove -Wno-unused-parameter

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -22,7 +22,7 @@ WARNING_FLAGS="-Wall"
 
 AS_CASE([$PLATFORM],
     [haiku],   [],
-               [WARNING_FLAGS="$WARNING_FLAGS -Wextra -Wno-unused-parameter"])
+               [WARNING_FLAGS="$WARNING_FLAGS -Wextra"])
 
 AC_ARG_WITH([libxml2],
     [AS_HELP_STRING([--with-libxml2], [use libxml2 for XML parsing, expat is the default])])

--- a/examples/active.c
+++ b/examples/active.c
@@ -26,6 +26,8 @@ int handle_reply(xmpp_conn_t * const conn,
     xmpp_stanza_t *query, *item;
     const char *type;
 
+    (void) userdata;
+
     type = xmpp_stanza_get_type(stanza);
     if (strcmp(type, "error") == 0)
 	fprintf(stderr, "ERROR: query failed\n");
@@ -48,6 +50,9 @@ void conn_handler(xmpp_conn_t * const conn, const xmpp_conn_event_t status,
 		  const int error, xmpp_stream_error_t * const stream_error,
 		  void * const userdata)
 {
+    (void) error;
+    (void) stream_error;
+
     xmpp_ctx_t *ctx = (xmpp_ctx_t *)userdata;
     xmpp_stanza_t *iq, *query;
 

--- a/examples/basic.c
+++ b/examples/basic.c
@@ -23,6 +23,9 @@ void conn_handler(xmpp_conn_t * const conn, const xmpp_conn_event_t status,
                   const int error, xmpp_stream_error_t * const stream_error,
                   void * const userdata)
 {
+    (void) error;
+    (void) stream_error;
+
     xmpp_ctx_t *ctx = (xmpp_ctx_t *)userdata;
     int secured;
 

--- a/examples/bot.c
+++ b/examples/bot.c
@@ -119,6 +119,9 @@ void conn_handler(xmpp_conn_t * const conn, const xmpp_conn_event_t status,
                   const int error, xmpp_stream_error_t * const stream_error,
                   void * const userdata)
 {
+    (void) error;
+    (void) stream_error;
+
     xmpp_ctx_t *ctx = (xmpp_ctx_t *)userdata;
 
     if (status == XMPP_CONN_CONNECT) {

--- a/examples/component.c
+++ b/examples/component.c
@@ -25,6 +25,9 @@ void conn_handler(xmpp_conn_t * const conn, const xmpp_conn_event_t status,
                   const int error, xmpp_stream_error_t * const stream_error,
                   void * const userdata)
 {
+    (void) error;
+    (void) stream_error;
+
     xmpp_ctx_t *ctx = (xmpp_ctx_t *)userdata;
 
     if (status == XMPP_CONN_CONNECT) {

--- a/examples/roster.c
+++ b/examples/roster.c
@@ -22,6 +22,8 @@ int handle_reply(xmpp_conn_t * const conn,
 		 xmpp_stanza_t * const stanza,
 		 void * const userdata)
 {
+    (void) userdata;
+
     xmpp_stanza_t *query, *item;
     const char *type, *name;
 
@@ -55,6 +57,10 @@ void conn_handler(xmpp_conn_t * const conn, const xmpp_conn_event_t status,
 		  const int error, xmpp_stream_error_t * const stream_error,
 		  void * const userdata)
 {
+    (void) error;
+    (void) stream_error;
+    (void) userdata;
+
     xmpp_ctx_t *ctx = (xmpp_ctx_t *)userdata;
     xmpp_stanza_t *iq, *query;
 

--- a/examples/uuid.c
+++ b/examples/uuid.c
@@ -3,6 +3,9 @@
 
 int main(int argc, char **argv)
 {
+    (void) argc;
+    (void) argv;
+
     xmpp_ctx_t *ctx;
     char *uuid;
     int rc = 0;

--- a/examples/vcard.c
+++ b/examples/vcard.c
@@ -167,6 +167,8 @@ exit:
 
 static int timedout(xmpp_conn_t * const conn, void * const userdata)
 {
+    (void) userdata;
+
     fprintf(stderr, "Timeout reached.\n");
     xmpp_disconnect(conn);
 

--- a/src/auth.c
+++ b/src/auth.c
@@ -110,6 +110,8 @@ static int _handle_error(xmpp_conn_t * const conn,
     xmpp_stanza_t *child;
     const char *name;
 
+    UNUSED(userdata);
+
     /* free old stream error if it's still there */
     if (conn->stream_error) {
 	xmpp_stanza_release(conn->stream_error->stanza);
@@ -200,6 +202,8 @@ static int _handle_error(xmpp_conn_t * const conn,
 static int _handle_missing_features(xmpp_conn_t * const conn,
 				    void * const userdata)
 {
+    UNUSED(userdata);
+
     xmpp_debug(conn->ctx, "xmpp", "didn't get stream features");
 
     /* legacy auth will be attempted */
@@ -214,6 +218,8 @@ static int _handle_features(xmpp_conn_t * const conn,
 			    xmpp_stanza_t * const stanza,
 			    void * const userdata)
 {
+    UNUSED(userdata);
+
     xmpp_stanza_t *child, *mech;
     const char *ns;
     char *text;
@@ -287,6 +293,8 @@ static int _handle_proceedtls_default(xmpp_conn_t * const conn,
 			      xmpp_stanza_t * const stanza,
 			      void * const userdata)
 {
+    UNUSED(userdata);
+
     const char *name;
 
     name = xmpp_stanza_get_name(stanza);
@@ -347,6 +355,8 @@ static int _handle_digestmd5_challenge(xmpp_conn_t * const conn,
 			      xmpp_stanza_t * const stanza,
 			      void * const userdata)
 {
+    UNUSED(userdata);
+
     char *text;
     char *response;
     xmpp_stanza_t *auth, *authdata;
@@ -404,6 +414,8 @@ static int _handle_digestmd5_rspauth(xmpp_conn_t * const conn,
 			      xmpp_stanza_t * const stanza,
 			      void * const userdata)
 {
+    UNUSED(userdata);
+
     xmpp_stanza_t *auth;
     const char *name;
 
@@ -787,6 +799,8 @@ static int _handle_features_sasl(xmpp_conn_t * const conn,
 				 xmpp_stanza_t * const stanza,
 				 void * const userdata)
 {
+    UNUSED(userdata);
+
     xmpp_stanza_t *bind, *session, *iq, *res, *text, *opt;
     const char *ns;
     char *resource;
@@ -891,6 +905,8 @@ static int _handle_features_sasl(xmpp_conn_t * const conn,
 static int _handle_missing_features_sasl(xmpp_conn_t * const conn,
 					 void * const userdata)
 {
+    UNUSED(userdata);
+
     xmpp_error(conn->ctx, "xmpp", "Did not receive stream features "\
 	       "after SASL authentication.");
     xmpp_disconnect(conn);
@@ -901,6 +917,8 @@ static int _handle_bind(xmpp_conn_t * const conn,
 			xmpp_stanza_t * const stanza,
 			void * const userdata)
 {
+    UNUSED(userdata);
+
     const char *type;
     xmpp_stanza_t *iq, *session;
 
@@ -972,6 +990,8 @@ static int _handle_bind(xmpp_conn_t * const conn,
 static int _handle_missing_bind(xmpp_conn_t * const conn,
 				void * const userdata)
 {
+    UNUSED(userdata);
+
     xmpp_error(conn->ctx, "xmpp", "Server did not reply to bind request.");
     xmpp_disconnect(conn);
     return 0;
@@ -981,6 +1001,8 @@ static int _handle_session(xmpp_conn_t * const conn,
 			   xmpp_stanza_t * const stanza,
 			   void * const userdata)
 {
+    UNUSED(userdata);
+
     const char *type;
 
     /* delete missing session handler */
@@ -1009,6 +1031,8 @@ static int _handle_session(xmpp_conn_t * const conn,
 static int _handle_missing_session(xmpp_conn_t * const conn,
 				   void * const userdata)
 {
+    UNUSED(userdata);
+
     xmpp_error(conn->ctx, "xmpp", "Server did not reply to session request.");
     xmpp_disconnect(conn);
     return 0;
@@ -1017,6 +1041,8 @@ static int _handle_missing_session(xmpp_conn_t * const conn,
 static int _handle_missing_legacy(xmpp_conn_t * const conn,
 				  void * const userdata)
 {
+    UNUSED(userdata);
+
     xmpp_error(conn->ctx, "xmpp", "Server did not reply to legacy "\
 	       "authentication request.");
     xmpp_disconnect(conn);
@@ -1027,6 +1053,8 @@ static int _handle_legacy(xmpp_conn_t * const conn,
 			  xmpp_stanza_t * const stanza,
 			  void * const userdata)
 {
+    UNUSED(userdata);
+
     const char *type;
     const char *name;
 
@@ -1224,6 +1252,8 @@ int _handle_component_hs_response(xmpp_conn_t * const conn,
             xmpp_stanza_t * const stanza,
             void * const userdata)
 {
+    UNUSED(userdata);
+
     const char *name;
 
     xmpp_timed_handler_delete(conn, _handle_missing_handshake);
@@ -1252,6 +1282,8 @@ int _handle_component_hs_response(xmpp_conn_t * const conn,
 
 int _handle_missing_handshake(xmpp_conn_t * const conn, void * const userdata)
 {
+    UNUSED(userdata);
+
     xmpp_error(conn->ctx, "xmpp", "Server did not reply to handshake request.");
     xmpp_disconnect(conn);
     return 0;

--- a/src/common.h
+++ b/src/common.h
@@ -133,6 +133,8 @@ struct _xmpp_handlist_t {
     };
 };
 
+#define UNUSED(x) (void)(x)
+
 #define MAX_DOMAIN_LEN 256
 
 #define SASL_MASK_PLAIN     (1 << 0)

--- a/src/conn.c
+++ b/src/conn.c
@@ -1006,6 +1006,8 @@ int xmpp_conn_is_secured(xmpp_conn_t * const conn)
 static int _disconnect_cleanup(xmpp_conn_t * const conn,
                                void * const userdata)
 {
+    UNUSED(userdata);
+
     xmpp_debug(conn->ctx, "xmpp",
                "disconnection forced by cleanup timeout");
 
@@ -1159,6 +1161,8 @@ static void _handle_stream_start(char *name, char **attrs,
 static void _handle_stream_end(char *name,
                                void * const userdata)
 {
+    UNUSED(name);
+
     xmpp_conn_t *conn = (xmpp_conn_t *)userdata;
 
     /* stream is over */

--- a/src/ctx.c
+++ b/src/ctx.c
@@ -124,16 +124,19 @@ int xmpp_version_check(int major, int minor)
  */
 static void *_malloc(const size_t size, void * const userdata)
 {
+    UNUSED(userdata);
     return malloc(size);
 }
 
 static void _free(void *p, void * const userdata)
 {
+    UNUSED(userdata);
     free(p);
 }
 
 static void *_realloc(void *p, const size_t size, void * const userdata)
 {
+    UNUSED(userdata);
     return realloc(p, size);
 }
 

--- a/src/md5.c
+++ b/src/md5.c
@@ -183,6 +183,8 @@ void MD5Final(unsigned char digest[16], struct MD5Context *ctx)
 static void MD5Transform(uint32_t buf[4], const unsigned char inext[64],
                          struct MD5Context *ctx)
 {
+    (void) ctx; // unused
+
     register uint32_t a, b, c, d, i;
     uint32_t in[16];
     

--- a/src/parser_libxml2.c
+++ b/src/parser_libxml2.c
@@ -110,6 +110,11 @@ static void _start_element(void *userdata,
                            const xmlChar **namespaces, int nattrs,
                            int ndefaulted, const xmlChar **attrs)
 {
+    UNUSED(prefix);
+    UNUSED(nnamespaces);
+    UNUSED(namespaces);
+    UNUSED(ndefaulted);
+
     parser_t *parser = (parser_t *)userdata;
     xmpp_stanza_t *child;
     char **cbattrs;
@@ -166,6 +171,9 @@ static void _start_element(void *userdata,
 static void _end_element(void *userdata, const xmlChar *name,
                          const xmlChar *prefix, const xmlChar *uri)
 {
+    UNUSED(prefix);
+    UNUSED(uri);
+
     parser_t *parser = (parser_t *)userdata;
 
     parser->depth--;

--- a/src/resolver.c
+++ b/src/resolver.c
@@ -472,6 +472,8 @@ static int resolver_ares_srv_lookup_buf(xmpp_ctx_t *ctx,
 static void ares_srv_lookup_callback(void *arg, int status, int timeouts,
                                      unsigned char *buf, int len)
 {
+    (void) timeouts;    
+
     struct resolver_ares_ctx *actx = arg;
 
     if (status != ARES_SUCCESS)

--- a/src/sasl.c
+++ b/src/sasl.c
@@ -171,6 +171,8 @@ static void _digest_to_hex(const char *digest, char *hex)
 static char *_add_key(xmpp_ctx_t *ctx, hash_t *table, const char *key, 
 		      char *buf, int *len, int quote)
 {
+    UNUSED(len);
+
     int olen,nlen;
     int keylen, valuelen;
     const char *value, *qvalue;
@@ -367,6 +369,8 @@ char *sasl_scram_sha1(xmpp_ctx_t *ctx, const char *challenge,
                       const char *first_bare, const char *jid,
                       const char *password)
 {
+    UNUSED(jid);
+
     uint8_t key[SHA1_DIGEST_SIZE];
     uint8_t sign[SHA1_DIGEST_SIZE];
     char *r = NULL;

--- a/src/tls_dummy.c
+++ b/src/tls_dummy.c
@@ -35,57 +35,73 @@ void tls_shutdown(void)
 
 tls_t *tls_new(xmpp_conn_t *conn)
 {
+    UNUSED(conn);
     /* always fail */
     return NULL;
 }
 
 void tls_free(tls_t *tls)
 {
+    UNUSED(tls);
     return;
 }
 
 int tls_set_credentials(tls_t *tls, const char *cafilename)
 {
+    UNUSED(tls);
+    UNUSED(cafilename);
     return -1;
 }
 
 int tls_start(tls_t *tls)
 {
+    UNUSED(tls);
     return -1;
 }
 
 int tls_stop(tls_t *tls)
 {
+    UNUSED(tls);
     return -1;
 }
 
 int tls_error(tls_t *tls)
 {
+    UNUSED(tls);
     /* todo: some kind of error polling/dump */
     return 0;
 }
 
 int tls_pending(tls_t *tls)
 {
+    UNUSED(tls);
     return 0;
 }
 
 int tls_read(tls_t *tls, void * const buff, const size_t len)
 {
+    UNUSED(tls);
+    UNUSED(buff);
+    UNUSED(len);
     return -1;
 }
 
 int tls_write(tls_t *tls, const void * const buff, const size_t len)
 {
+    UNUSED(tls);
+    UNUSED(buff);
+    UNUSED(len);
     return -1;
 }
 
 int tls_clear_pending_write(tls_t *tls)
 {
+    UNUSED(tls);
     return -1;
 }
 
 int tls_is_recoverable(int error)
 {
+    UNUSED(error);
     return 0;
 }

--- a/src/tls_gnutls.c
+++ b/src/tls_gnutls.c
@@ -142,5 +142,6 @@ int tls_write(tls_t *tls, const void * const buff, const size_t len)
 
 int tls_clear_pending_write(tls_t *tls)
 {
+    UNUSED(tls);
     return 0;
 }

--- a/src/tls_openssl.c
+++ b/src/tls_openssl.c
@@ -196,6 +196,8 @@ void tls_free(tls_t *tls)
 
 int tls_set_credentials(tls_t *tls, const char *cafilename)
 {
+    UNUSED(tls);
+    UNUSED(cafilename);
     return -1;
 }
 
@@ -299,6 +301,7 @@ int tls_write(tls_t *tls, const void * const buff, const size_t len)
 
 int tls_clear_pending_write(tls_t *tls)
 {
+    UNUSED(tls);
     return 0;
 }
 

--- a/src/tls_schannel.c
+++ b/src/tls_schannel.c
@@ -210,6 +210,8 @@ void tls_free(tls_t *tls)
 
 int tls_set_credentials(tls_t *tls, const char *cafilename)
 {
+    UNUSED(tls);
+    UNUSED(cafilename);
     return -1;
 }
 
@@ -385,6 +387,7 @@ int tls_start(tls_t *tls)
 
 int tls_stop(tls_t *tls)
 {
+    UNUSED(tls);
     return -1;
 }
 

--- a/tests/check_parser.c
+++ b/tests/check_parser.c
@@ -42,6 +42,8 @@ static void create_destroy(void)
 int cbtest_got_start = 0;
 void cbtest_handle_start(char *name, char **attrs, void *userdata)
 {
+    (void) attrs;
+    (void) userdata;
     if (strcmp(name, "stream") == 0)
         cbtest_got_start = 1;
 }
@@ -49,6 +51,7 @@ void cbtest_handle_start(char *name, char **attrs, void *userdata)
 int cbtest_got_end = 0;
 void cbtest_handle_end(char *name, void *userdata)
 {
+    (void) userdata;
     if (strcmp(name, "stream") == 0)
         cbtest_got_end = 1;
 }
@@ -56,6 +59,7 @@ void cbtest_handle_end(char *name, void *userdata)
 int cbtest_got_stanza = 0;
 void cbtest_handle_stanza(xmpp_stanza_t *stanza, void *userdata)
 {
+    (void) userdata;
     if (strcmp(xmpp_stanza_get_name(stanza), "message") == 0)
         cbtest_got_stanza = 1;
 }

--- a/tests/test_base64.c
+++ b/tests/test_base64.c
@@ -128,7 +128,7 @@ static const unsigned char bin_data[] = {
     0x6d, 0x00,
 };
 
-int main(int argc, char *argv[])
+int main(void)
 {
     xmpp_ctx_t *ctx;
     unsigned char *udec;

--- a/tests/test_ctx.c
+++ b/tests/test_ctx.c
@@ -23,18 +23,21 @@ static int mem_realloc_called = 0;
 
 void *my_alloc(const size_t size, void * const userdata)
 {
+    (void) userdata;
     mem_alloc_called++;
     return malloc(size);
 }
 
 void my_free(void *p, void * const userdata)
 {
+    (void) userdata;
     mem_free_called++;
     return free(p);
 }
 
 void *my_realloc(void *p, const size_t size, void * const userdata)
 {
+    (void) userdata;
     mem_realloc_called++;
     return realloc(p, size);
 }
@@ -47,7 +50,7 @@ void my_logger(void * const userdata, const xmpp_log_level_t level,
 	log_called++;
 }
 
-int main(int argc, char **argv)
+int main(void)
 {
     xmpp_ctx_t *ctx;
     xmpp_mem_t mymem;

--- a/tests/test_jid.c
+++ b/tests/test_jid.c
@@ -112,7 +112,7 @@ int test_jid_new(xmpp_ctx_t *ctx)
     return 0;
 }
 
-int main(int argc, char *argv[])
+int main(void)
 {
     xmpp_ctx_t *ctx;
     int ret;

--- a/tests/test_md5.c
+++ b/tests/test_md5.c
@@ -57,7 +57,7 @@ static const struct {
     },
 };
 
-int main(int argc, char **argv)
+int main(void)
 {
     struct MD5Context ctx;
     unsigned char digest[16];

--- a/tests/test_rand.c
+++ b/tests/test_rand.c
@@ -22,10 +22,18 @@
 
 /* stubs to build test without whole libstrophe */
 void *xmpp_alloc(const xmpp_ctx_t * const ctx, const size_t size) {
+    (void) ctx;
+    (void) size;
     return NULL;
 }
-void xmpp_free(const xmpp_ctx_t * const ctx, void *p) { }
+void xmpp_free(const xmpp_ctx_t * const ctx, void *p) {
+    (void) ctx;
+    (void) p;
+}
 int xmpp_snprintf (char *str, size_t count, const char *fmt, ...) {
+    (void) str;
+    (void) count;
+    (void) fmt;
     return 0;
 }
 uint64_t time_stamp(void) {

--- a/tests/test_resolver.c
+++ b/tests/test_resolver.c
@@ -192,7 +192,7 @@ static int srv_rr_list_len(resolver_srv_rr_t *list)
     return nr;
 }
 
-int main(int argc, char **argv)
+int main(void)
 {
     xmpp_ctx_t *ctx;
     xmpp_rand_t *rand;

--- a/tests/test_sasl.c
+++ b/tests/test_sasl.c
@@ -80,7 +80,7 @@ int test_digest_md5(xmpp_ctx_t *ctx)
     return 0;
 }
 
-int main(int argc, char *argv[])
+int main(void)
 {
     xmpp_ctx_t *ctx;
     int ret;

--- a/tests/test_scram.c
+++ b/tests/test_scram.c
@@ -133,7 +133,7 @@ static void test_scram(void)
     }
 }
 
-int main(int argc, char **argv)
+int main(void)
 {
     test_df();
     test_scram();

--- a/tests/test_sha1.c
+++ b/tests/test_sha1.c
@@ -39,7 +39,7 @@ static void digest_to_hex(const uint8_t *digest, char *output)
     *(c - 1) = '\0';
 }
 
-int main(int argc, char** argv)
+int main(void)
 {
     int k;
     SHA1_CTX context;

--- a/tests/test_sock.c
+++ b/tests/test_sock.c
@@ -35,7 +35,7 @@ int wait_for_connect(sock_t sock)
     return -1;
 }
 
-int main(int argc, char **argv)
+int main(void)
 {
     sock_t sock;
     int err;


### PR DESCRIPTION
Introduced UNUSED macro with cast to void in commoh.h for internal
use. Used cast to void directly in those files which do not
include common.h. Although this change doesn't fix semantic issues
with unused function parameters, it does explicitly mark all those
places, which might require attention in future.