### PR TITLE
Add basic fuzzing support for libstrophe

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -171,6 +171,16 @@ endif
 
 check_PROGRAMS = $(TESTS)
 
+if FUZZ
+check_PROGRAMS += tests/test_fuzz
+
+tests_test_fuzz_SOURCES = tests/test_fuzz.c
+tests_test_fuzz_CFLAGS = -fsanitize=fuzzer,address  $(PARSER_CFLAGS) $(STROPHE_FLAGS) \
+	-I$(top_srcdir)/src
+tests_test_fuzz_LDADD = $(STROPHE_LIBS)
+tests_test_fuzz_LDFLAGS = -static
+endif
+
 tests_check_parser_SOURCES = tests/check_parser.c tests/test.h
 tests_check_parser_CFLAGS = $(PARSER_CFLAGS) $(STROPHE_FLAGS) \
 	-I$(top_srcdir)/src

--- a/configure.ac
+++ b/configure.ac
@@ -33,6 +33,16 @@ AC_ARG_ENABLE([tls],
 AC_ARG_ENABLE([cares],
     [AS_HELP_STRING([--enable-cares], [use c-ares for DNS resolution])])
 
+AC_ARG_ENABLE([fuzzing], [--enable-fuzzing    Turn on fuzzing],
+	      [case "${enableval}" in yes) fuzzing=true ;; no)  fuzzing=false ;; *) AC_MSG_ERROR([bad value ${enableval} for --enable-fuzzing]) ;; esac],[fuzzing=false])
+AM_CONDITIONAL([FUZZ], [test x$fuzzing = xtrue])
+
+if test "x$enable_fuzzing" = "xyes" ; then
+	if ! test "x$CC" = "xclang" ; then
+		AC_MSG_ERROR(["You need to set CC=clang to use --enable-fuzzing, used $CC"])
+	fi
+fi
+
 AC_SEARCH_LIBS([socket], [network socket])
 AC_CHECK_FUNCS([snprintf vsnprintf])
 AC_CHECK_DECLS([va_copy], [], [], [#include <stdarg.h>])

--- a/tests/test_fuzz.c
+++ b/tests/test_fuzz.c
@@ -1,0 +1,49 @@
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "strophe.h"
+#include "parser.h"
+
+void xmpp_initialize(void);
+
+void cbtest_handle_start(char *name, char **attrs, void *userdata)
+{
+    (void)name;
+    (void)attrs;
+    (void)userdata;
+}
+
+void cbtest_handle_end(char *name, void *userdata)
+{
+    (void)name;
+    (void)userdata;
+}
+
+void cbtest_handle_stanza(xmpp_stanza_t *stanza, void *userdata)
+{
+    (void)stanza;
+    (void)userdata;
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
+{
+    xmpp_ctx_t *ctx;
+    parser_t *parser;
+
+    char *dup = malloc(Size);
+    memcpy(dup, Data, Size);
+
+    ctx = xmpp_ctx_new(NULL, NULL);
+    parser = parser_new(ctx, cbtest_handle_start, cbtest_handle_end,
+                        cbtest_handle_stanza, NULL);
+
+    parser_feed(parser, dup, Size);
+
+    free(dup);
+    parser_free(parser);
+    xmpp_ctx_free(ctx);
+
+    return 0;
+}


### PR DESCRIPTION
Hi! 

Based on https://github.com/profanity-im/profanity/issues/1509#issuecomment-858110643 I added some fuzzing support to libstrophe. 

I added the fuzzer to the `TESTS` in the Makefile after the `check_PROGRAMS` because you don't want to run this in your `test-driver`, this would cause your tests to wait until the fuzzer caused a crash. Therefore I added this later.

This compiles perfectly for me and I can run the fuzzer with:

```bash
libstrophe# ./tests/test_fuzz
INFO: Running with entropic power schedule (0xFF, 100).
INFO: Seed: 2708216363
INFO: Loaded 1 modules   (4 inline 8-bit counters): 4 [0x5c4440, 0x5c4444),
INFO: Loaded 1 PC tables (4 PCs): 4 [0x583610,0x583650),
INFO: -max_len is not provided; libFuzzer will not generate inputs larger than 4096 bytes
INFO: A corpus is not provided, starting from an empty corpus
#2      INITED cov: 1 ft: 1 corp: 1/1b exec/s: 0 rss: 32Mb
```

Best Regards,

Jordy Zomer