### PR TITLE
Implement XEP-0198

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ tests/test_rand
 tests/test_resolver
 tests/test_sasl
 tests/test_scram
+tests/test_send_queue
 tests/test_sha1
 tests/test_sha256
 tests/test_sha512

--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,7 @@
 	- Add support for password-protected TLS key & PKCS#12/PFX files
 	- New API:
 		- xmpp_conn_send_queue_len()
+		- xmpp_conn_send_queue_drop_element()
 		- xmpp_conn_get_keyfile()
 		- xmpp_conn_set_password_callback()
 		- xmpp_conn_set_password_retries()

--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,7 @@
 	- Add code coverage support
 	- Add support for password-protected TLS key & PKCS#12/PFX files
 	- New API:
+		- xmpp_conn_send_queue_len()
 		- xmpp_conn_get_keyfile()
 		- xmpp_conn_set_password_callback()
 		- xmpp_conn_set_password_retries()

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,9 +2,13 @@
 	- Fix potential infinite loop in resolver (#200)
 	- Add code coverage support
 	- Add support for password-protected TLS key & PKCS#12/PFX files
+	- Stream-Management support (XEP-0198)
 	- New API:
 		- xmpp_conn_send_queue_len()
 		- xmpp_conn_send_queue_drop_element()
+		- xmpp_conn_get_sm_state()
+		- xmpp_conn_set_sm_state()
+		- xmpp_free_sm_state()
 		- xmpp_conn_get_keyfile()
 		- xmpp_conn_set_password_callback()
 		- xmpp_conn_set_password_retries()

--- a/Makefile.am
+++ b/Makefile.am
@@ -178,6 +178,7 @@ TESTS = \
 	tests/test_base64 \
 	tests/test_hash \
 	tests/test_jid \
+	tests/test_send_queue \
 	tests/test_snprintf \
 	tests/test_string \
 	tests/test_stanza \
@@ -254,6 +255,11 @@ tests_test_sha512_CFLAGS = -I$(top_srcdir)/src
 
 tests_test_md5_SOURCES = tests/test_md5.c tests/test.c src/md5.c
 tests_test_md5_CFLAGS = -I$(top_srcdir)/src
+
+tests_test_send_queue_SOURCES = tests/test_send_queue.c
+tests_test_send_queue_CFLAGS = -I$(top_srcdir)/src
+tests_test_send_queue_LDADD = $(STROPHE_LIBS)
+tests_test_send_queue_LDFLAGS = -static
 
 tests_test_snprintf_SOURCES = tests/test_snprintf.c
 tests_test_snprintf_CFLAGS = -I$(top_srcdir)/src

--- a/src/auth.c
+++ b/src/auth.c
@@ -397,7 +397,7 @@ static int _handle_digestmd5_challenge(xmpp_conn_t *conn,
         handler_add(conn, _handle_digestmd5_rspauth, XMPP_NS_SASL, NULL, NULL,
                     NULL);
 
-        xmpp_send(conn, auth);
+        send_stanza(conn, auth, XMPP_QUEUE_STROPHE);
         xmpp_stanza_release(auth);
 
     } else {
@@ -431,7 +431,7 @@ static int _handle_digestmd5_rspauth(xmpp_conn_t *conn,
         }
         xmpp_stanza_set_name(auth, "response");
         xmpp_stanza_set_ns(auth, XMPP_NS_SASL);
-        xmpp_send(conn, auth);
+        send_stanza(conn, auth, XMPP_QUEUE_STROPHE);
         xmpp_stanza_release(auth);
     } else {
         return _handle_sasl_result(conn, stanza, "DIGEST-MD5");
@@ -494,7 +494,7 @@ static int _handle_scram_challenge(xmpp_conn_t *conn,
         xmpp_stanza_add_child(auth, authdata);
         xmpp_stanza_release(authdata);
 
-        xmpp_send(conn, auth);
+        send_stanza(conn, auth, XMPP_QUEUE_STROPHE);
         xmpp_stanza_release(auth);
 
         rc = 1; /* Keep handler */
@@ -624,7 +624,7 @@ static void _auth(xmpp_conn_t *conn)
         handler_add(conn, _handle_proceedtls_default, XMPP_NS_TLS, NULL, NULL,
                     NULL);
 
-        xmpp_send(conn, auth);
+        send_stanza(conn, auth, XMPP_QUEUE_STROPHE);
         xmpp_stanza_release(auth);
 
         /* TLS was tried, unset flag */
@@ -652,7 +652,7 @@ static void _auth(xmpp_conn_t *conn)
         handler_add(conn, _handle_sasl_result, XMPP_NS_SASL, NULL, NULL,
                     "ANONYMOUS");
 
-        xmpp_send(conn, auth);
+        send_stanza(conn, auth, XMPP_QUEUE_STROPHE);
         xmpp_stanza_release(auth);
 
         /* SASL ANONYMOUS was tried, unset flag */
@@ -695,7 +695,7 @@ static void _auth(xmpp_conn_t *conn)
         handler_add(conn, _handle_sasl_result, XMPP_NS_SASL, NULL, NULL,
                     "EXTERNAL");
 
-        xmpp_send(conn, auth);
+        send_stanza(conn, auth, XMPP_QUEUE_STROPHE);
         xmpp_stanza_release(auth);
 
         /* SASL EXTERNAL was tried, unset flag */
@@ -760,7 +760,7 @@ static void _auth(xmpp_conn_t *conn)
         handler_add(conn, _handle_scram_challenge, XMPP_NS_SASL, NULL, NULL,
                     (void *)scram_ctx);
 
-        xmpp_send(conn, auth);
+        send_stanza(conn, auth, XMPP_QUEUE_STROPHE);
         xmpp_stanza_release(auth);
 
         /* SASL SCRAM-SHA-1 was tried, unset flag */
@@ -775,7 +775,7 @@ static void _auth(xmpp_conn_t *conn)
         handler_add(conn, _handle_digestmd5_challenge, XMPP_NS_SASL, NULL, NULL,
                     NULL);
 
-        xmpp_send(conn, auth);
+        send_stanza(conn, auth, XMPP_QUEUE_STROPHE);
         xmpp_stanza_release(auth);
 
         /* SASL DIGEST-MD5 was tried, unset flag */
@@ -811,7 +811,7 @@ static void _auth(xmpp_conn_t *conn)
         handler_add(conn, _handle_sasl_result, XMPP_NS_SASL, NULL, NULL,
                     "PLAIN");
 
-        xmpp_send(conn, auth);
+        send_stanza(conn, auth, XMPP_QUEUE_STROPHE);
         xmpp_stanza_release(auth);
 
         /* SASL PLAIN was tried */
@@ -978,7 +978,7 @@ _handle_features_sasl(xmpp_conn_t *conn, xmpp_stanza_t *stanza, void *userdata)
         xmpp_stanza_release(bind);
 
         /* send bind request */
-        xmpp_send(conn, iq);
+        send_stanza(conn, iq, XMPP_QUEUE_STROPHE);
         xmpp_stanza_release(iq);
     } else {
         /* can't bind, disconnect */
@@ -1057,7 +1057,7 @@ _handle_bind(xmpp_conn_t *conn, xmpp_stanza_t *stanza, void *userdata)
             xmpp_stanza_release(session);
 
             /* send session establishment request */
-            xmpp_send(conn, iq);
+            send_stanza(conn, iq, XMPP_QUEUE_STROPHE);
             xmpp_stanza_release(iq);
         }
 
@@ -1070,7 +1070,7 @@ _handle_bind(xmpp_conn_t *conn, xmpp_stanza_t *stanza, void *userdata)
             xmpp_stanza_set_name(enable, "enable");
             xmpp_stanza_set_ns(enable, XMPP_NS_SM);
             handler_add(conn, _handle_sm, XMPP_NS_SM, NULL, NULL, NULL);
-            xmpp_send(conn, enable);
+            send_stanza(conn, enable, XMPP_QUEUE_SM_STROPHE);
             xmpp_stanza_release(enable);
             conn->sm_sent_nr = 0;
         }
@@ -1284,7 +1284,7 @@ static void _auth_legacy(xmpp_conn_t *conn)
     handler_add_id(conn, _handle_legacy, "_xmpp_auth1", NULL);
     handler_add_timed(conn, _handle_missing_legacy, LEGACY_TIMEOUT, NULL);
 
-    xmpp_send(conn, iq);
+    send_stanza(conn, iq, XMPP_QUEUE_STROPHE);
     xmpp_stanza_release(iq);
     return;
 
@@ -1347,8 +1347,8 @@ int _handle_component_auth(xmpp_conn_t *conn)
                       strlen(digest));
 
         /* Send the digest to the server */
-        xmpp_send_raw_string(conn, "<handshake xmlns='%s'>%s</handshake>",
-                             XMPP_NS_COMPONENT, digest);
+        send_raw_string(conn, "<handshake xmlns='%s'>%s</handshake>",
+                        XMPP_NS_COMPONENT, digest);
         strophe_debug(conn->ctx, "auth",
                       "Sent component handshake to the server.");
         strophe_free(conn->ctx, digest);

--- a/src/common.h
+++ b/src/common.h
@@ -204,6 +204,10 @@ struct _xmpp_conn_t {
     /* if server returns <bind/> or <session/> we must do them */
     int bind_required;
     int session_required;
+    int sm_support;
+    int sm_enabled;
+    uint32_t sm_handled_nr;
+    uint32_t sm_sent_nr;
 
     char *lang;
     char *domain;

--- a/src/common.h
+++ b/src/common.h
@@ -128,11 +128,19 @@ typedef enum {
     XMPP_STATE_CONNECTED
 } xmpp_conn_state_t;
 
+typedef enum {
+    XMPP_QUEUE_STROPHE = 0x1,
+    XMPP_QUEUE_USER = 0x2,
+    XMPP_QUEUE_SM = 0x800,
+    XMPP_QUEUE_SM_STROPHE = XMPP_QUEUE_SM | XMPP_QUEUE_STROPHE,
+} xmpp_send_queue_owner_t;
+
 typedef struct _xmpp_send_queue_t xmpp_send_queue_t;
 struct _xmpp_send_queue_t {
     char *data;
     size_t len;
     size_t written;
+    xmpp_send_queue_owner_t owner;
 
     xmpp_send_queue_t *next;
 };
@@ -220,6 +228,7 @@ struct _xmpp_conn_t {
     int blocking_send;
     int send_queue_max;
     int send_queue_len;
+    int send_queue_user_len;
     xmpp_send_queue_t *send_queue_head;
     xmpp_send_queue_t *send_queue_tail;
 
@@ -307,5 +316,18 @@ void auth_handle_open(xmpp_conn_t *conn);
 void auth_handle_component_open(xmpp_conn_t *conn);
 void auth_handle_open_raw(xmpp_conn_t *conn);
 void auth_handle_open_stub(xmpp_conn_t *conn);
+
+/* send functions */
+void send_raw(xmpp_conn_t *conn,
+              const char *data,
+              size_t len,
+              xmpp_send_queue_owner_t owner);
+/* this is a bit special as it will always mark the sent string as
+ * owned by libstrophe
+ */
+void send_raw_string(xmpp_conn_t *conn, const char *fmt, ...);
+void send_stanza(xmpp_conn_t *conn,
+                 xmpp_stanza_t *stanza,
+                 xmpp_send_queue_owner_t owner);
 
 #endif /* __LIBSTROPHE_COMMON_H__ */

--- a/src/conn.c
+++ b/src/conn.c
@@ -1252,6 +1252,20 @@ int xmpp_conn_is_disconnected(xmpp_conn_t *conn)
     return conn->state == XMPP_STATE_DISCONNECTED;
 }
 
+/**
+ *  @return The number of entries in the send queue
+ *
+ *  @ingroup Connections
+ */
+int xmpp_conn_send_queue_len(const xmpp_conn_t *conn)
+{
+    if (conn->send_queue_head && conn->send_queue_head->written &&
+        conn->send_queue_head->owner == XMPP_QUEUE_USER)
+        return conn->send_queue_user_len - 1;
+    else
+        return conn->send_queue_user_len;
+}
+
 /* timed handler for cleanup if normal disconnect procedure takes too long */
 static int _disconnect_cleanup(xmpp_conn_t *conn, void *userdata)
 {

--- a/src/crypto.c
+++ b/src/crypto.c
@@ -22,11 +22,11 @@
 #include <assert.h>
 #include <string.h> /* memset, memcpy */
 
-#include "common.h"  /* xmpp_alloc */
+#include "common.h"  /* strophe_alloc */
 #include "ostypes.h" /* uint8_t, size_t */
 #include "sha1.h"
 #include "snprintf.h" /* xmpp_snprintf */
-#include "strophe.h"  /* xmpp_ctx_t, xmpp_free */
+#include "strophe.h"  /* xmpp_ctx_t, strophe_free */
 
 struct _xmpp_sha1_t {
     xmpp_ctx_t *xmpp_ctx;
@@ -187,9 +187,9 @@ char *xmpp_sha1_to_string(xmpp_sha1_t *sha1, char *s, size_t slen)
 }
 
 /** Return message digest rendered as a string.
- *  Returns an allocated string. Free the string using the Strophe context
- *  which is passed to xmpp_sha1_new(). Call this function after
- *  xmpp_sha1_final().
+ *  Returns an allocated string. Free the string by calling xmpp_free() using
+ *  the Strophe context which is passed to xmpp_sha1_new(). Call this function
+ *  after xmpp_sha1_final().
  *
  *  @param sha1 a SHA1 object
  *

--- a/src/ctx.c
+++ b/src/ctx.c
@@ -255,8 +255,8 @@ void *strophe_realloc(const xmpp_ctx_t *ctx, void *p, size_t size)
  *  Write a log message to the logger for the context for the specified
  *  level and area.  This function takes a printf-style format string and a
  *  variable argument list (in va_list) format.  This function is not meant
- *  to be called directly, but is used via xmpp_error, xmpp_warn, xmpp_info,
- *  and xmpp_debug.
+ *  to be called directly, but is used via strophe_error, strophe_warn,
+ * strophe_info, and strophe_debug.
  *
  *  @param ctx a Strophe context object
  *  @param level the level at which to log

--- a/src/event.c
+++ b/src/event.c
@@ -142,6 +142,8 @@ void xmpp_run_once(xmpp_ctx_t *ctx, unsigned long timeout)
             tsq = sq;
             sq = sq->next;
             conn->send_queue_len--;
+            if (tsq->owner & XMPP_QUEUE_USER)
+                conn->send_queue_user_len--;
             strophe_free(ctx, tsq);
 
             /* pop the top item */

--- a/src/rand.c
+++ b/src/rand.c
@@ -32,7 +32,7 @@
 #endif
 #endif
 
-#include "common.h"  /* xmpp_alloc, xmpp_free */
+#include "common.h"  /* strophe_alloc, strophe_free */
 #include "ostypes.h" /* uint8_t, uint32_t, size_t */
 
 #ifndef USE_GETRANDOM

--- a/src/stanza.c
+++ b/src/stanza.c
@@ -1509,7 +1509,7 @@ xmpp_stanza_t *xmpp_presence_new(xmpp_ctx_t *ctx)
  *  The error text is optional and may be NULL.
  *
  *  @param ctx a Strophe context object
- *  @param type enum of xmpp_error_type_t
+ *  @param type enum of strophe_error_type_t
  *  @param text content of a 'text'
  *
  *  @return a new Strophe stanza object

--- a/src/tls.c
+++ b/src/tls.c
@@ -103,7 +103,7 @@ const char *xmpp_tlscert_get_dnsname(const xmpp_tlscert_t *cert, size_t n)
 const char *xmpp_tlscert_get_string(const xmpp_tlscert_t *cert,
                                     xmpp_cert_element_t elmnt)
 {
-    if (elmnt >= XMPP_CERT_ELEMENT_MAX)
+    if (elmnt < 0 || elmnt >= XMPP_CERT_ELEMENT_MAX)
         return NULL;
     return cert->elements[elmnt];
 }
@@ -132,7 +132,7 @@ const char *xmpp_tlscert_get_description(xmpp_cert_element_t elmnt)
         "Fingerprint SHA-1",
         "Fingerprint SHA-256",
     };
-    if (elmnt >= XMPP_CERT_ELEMENT_MAX)
+    if (elmnt < 0 || elmnt >= XMPP_CERT_ELEMENT_MAX)
         return NULL;
     return descriptions[elmnt];
 }

--- a/src/tls_openssl.c
+++ b/src/tls_openssl.c
@@ -883,9 +883,13 @@ static const char *_tls_error_str(int error, const char **tbl, size_t tbl_size)
 static void _tls_set_error(tls_t *tls, int error)
 {
     if (error != 0 && !tls_is_recoverable(error)) {
-        strophe_debug(tls->ctx, "tls", "error=%s(%d) errno=%d",
-                      TLS_ERROR_STR(error, tls_errors), error, errno);
+        strophe_debug(tls->ctx, "tls", "error=%s(%d) errno=%d lasterror=%d",
+                      TLS_ERROR_STR(error, tls_errors), error, errno,
+                      tls->lasterror);
         _tls_log_error(tls->ctx);
+    } else if (tls->lasterror && tls->lasterror != error) {
+        strophe_debug_verbose(1, tls->ctx, "tls", "overwrite lasterror=%d",
+                              tls->lasterror);
     }
     tls->lasterror = error;
 }

--- a/src/util.c
+++ b/src/util.c
@@ -15,6 +15,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
 
 #ifdef _WIN32
 #include <winsock2.h>
@@ -159,6 +160,13 @@ void disconnect_mem_error(xmpp_conn_t *conn)
 {
     strophe_error(conn->ctx, "xmpp", "Memory allocation error");
     xmpp_disconnect(conn);
+}
+
+int string_to_ul(const char *s, unsigned long *ul)
+{
+    char *endptr;
+    *ul = strtoul(s, &endptr, 10);
+    return *endptr != '\0';
 }
 
 void hex_encode(char *writebuf, void *readbuf, size_t len)

--- a/src/util.h
+++ b/src/util.h
@@ -33,6 +33,7 @@ uint64_t time_stamp(void);
 uint64_t time_elapsed(uint64_t t1, uint64_t t2);
 
 /* misc functions */
+int string_to_ul(const char *s, unsigned long *ul);
 void hex_encode(char *writebuf, void *readbuf, size_t len);
 
 #endif /* __LIBSTROPHE_UTIL_H__ */

--- a/strophe.h
+++ b/strophe.h
@@ -79,6 +79,10 @@ extern "C" {
  *  Namespace definition for 'jabber:iq:register'.
  */
 #define XMPP_NS_REGISTER "jabber:iq:register"
+/** @def XMPP_NS_SM
+ *  Namespace definition for Stream Management.
+ */
+#define XMPP_NS_SM "urn:xmpp:sm:3"
 
 /* error defines */
 /** @def XMPP_EOK

--- a/strophe.h
+++ b/strophe.h
@@ -172,6 +172,7 @@ xmpp_log_t *xmpp_get_default_logger(xmpp_log_level_t level);
 /* opaque connection object */
 typedef struct _xmpp_conn_t xmpp_conn_t;
 typedef struct _xmpp_stanza_t xmpp_stanza_t;
+typedef struct _xmpp_sm_t xmpp_sm_state_t;
 
 /* connection flags */
 #define XMPP_CONN_FLAG_DISABLE_TLS (1UL << 0)
@@ -185,6 +186,10 @@ typedef struct _xmpp_stanza_t xmpp_stanza_t;
  *  Enable legacy authentication support.
  */
 #define XMPP_CONN_FLAG_LEGACY_AUTH (1UL << 4)
+/** @def XMPP_CONN_FLAG_DISABLE_SM
+ *  Disable Stream-Management XEP-0198.
+ */
+#define XMPP_CONN_FLAG_DISABLE_SM (1UL << 5)
 
 /* connect callback */
 typedef enum {
@@ -391,6 +396,11 @@ typedef enum {
 } xmpp_queue_element_t;
 char *xmpp_conn_send_queue_drop_element(xmpp_conn_t *conn,
                                         xmpp_queue_element_t which);
+
+xmpp_sm_state_t *xmpp_conn_get_sm_state(xmpp_conn_t *conn);
+int xmpp_conn_set_sm_state(xmpp_conn_t *conn, xmpp_sm_state_t *sm_state);
+
+void xmpp_free_sm_state(xmpp_sm_state_t *sm_state);
 
 int xmpp_connect_client(xmpp_conn_t *conn,
                         const char *altdomain,

--- a/strophe.h
+++ b/strophe.h
@@ -383,6 +383,7 @@ void xmpp_conn_set_sockopt_callback(xmpp_conn_t *conn,
 int xmpp_conn_is_connecting(xmpp_conn_t *conn);
 int xmpp_conn_is_connected(xmpp_conn_t *conn);
 int xmpp_conn_is_disconnected(xmpp_conn_t *conn);
+int xmpp_conn_send_queue_len(const xmpp_conn_t *conn);
 
 int xmpp_connect_client(xmpp_conn_t *conn,
                         const char *altdomain,

--- a/strophe.h
+++ b/strophe.h
@@ -385,6 +385,13 @@ int xmpp_conn_is_connected(xmpp_conn_t *conn);
 int xmpp_conn_is_disconnected(xmpp_conn_t *conn);
 int xmpp_conn_send_queue_len(const xmpp_conn_t *conn);
 
+typedef enum {
+    XMPP_QUEUE_OLDEST = -1,
+    XMPP_QUEUE_YOUNGEST = -2,
+} xmpp_queue_element_t;
+char *xmpp_conn_send_queue_drop_element(xmpp_conn_t *conn,
+                                        xmpp_queue_element_t which);
+
 int xmpp_connect_client(xmpp_conn_t *conn,
                         const char *altdomain,
                         unsigned short altport,

--- a/tests/test.h
+++ b/tests/test.h
@@ -61,6 +61,19 @@
         }                                                              \
     } while (0)
 
+#define ENSURE_EQ(v1, v2)                       \
+    do {                                        \
+        int __v1 = v1;                          \
+        int __v2 = v2;                          \
+        if (__v1 != __v2) {                     \
+            printf("Error:    %s\n"             \
+                   "Expected: %d\n"             \
+                   "Got:      %d\n",            \
+                   #v1 " != " #v2, __v2, __v1); \
+            exit(1);                            \
+        }                                       \
+    } while (0)
+
 void test_hex_to_bin(const char *hex, uint8_t *bin, size_t *bin_len);
 const char *test_bin_to_hex(const uint8_t *bin, size_t len);
 

--- a/tests/test_send_queue.c
+++ b/tests/test_send_queue.c
@@ -1,0 +1,86 @@
+/* test_send_queue.c
+** libstrophe XMPP client library -- test routines for the send queue
+**
+** Copyright (C) 2021 Steffen Jaeckel
+**
+**  This software is provided AS-IS with no warranty, either express
+**  or implied.
+**
+**  This program is dual licensed under the MIT and GPLv3 licenses.
+*/
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "strophe.h"
+#include "common.h"
+
+#include "test.h"
+
+int main()
+{
+    xmpp_ctx_t *ctx;
+    xmpp_conn_t *conn;
+    xmpp_log_t *log;
+    xmpp_conn_state_t state;
+    char *ret;
+
+    unsigned int n;
+
+    xmpp_initialize();
+    log = xmpp_get_default_logger(XMPP_LEVEL_DEBUG);
+    ctx = xmpp_ctx_new(NULL, log);
+    conn = xmpp_conn_new(ctx);
+
+    ENSURE_EQ(xmpp_conn_send_queue_len(conn), 0);
+
+    state = conn->state;
+    conn->state = XMPP_STATE_CONNECTED;
+
+    xmpp_send_raw(conn, "foo", 3);
+    ENSURE_EQ(xmpp_conn_send_queue_len(conn), 1);
+
+    xmpp_send_raw(conn, "bar", 3);
+    ENSURE_EQ(xmpp_conn_send_queue_len(conn), 2);
+
+    xmpp_send_raw(conn, "baz", 3);
+    ENSURE_EQ(xmpp_conn_send_queue_len(conn), 3);
+
+    xmpp_send_raw(conn, "baan", 4);
+    ENSURE_EQ(xmpp_conn_send_queue_len(conn), 4);
+
+    conn->send_queue_head->written = 1;
+    ENSURE_EQ(xmpp_conn_send_queue_len(conn), 3);
+
+    ret = xmpp_conn_send_queue_drop_element(conn, XMPP_QUEUE_OLDEST);
+    COMPARE("bar", ret);
+    xmpp_free(ctx, ret);
+    ENSURE_EQ(xmpp_conn_send_queue_len(conn), 2);
+
+    conn->send_queue_head->written = 0;
+    ENSURE_EQ(xmpp_conn_send_queue_len(conn), 3);
+
+    ret = xmpp_conn_send_queue_drop_element(conn, XMPP_QUEUE_OLDEST);
+    COMPARE("foo", ret);
+    xmpp_free(ctx, ret);
+    ENSURE_EQ(xmpp_conn_send_queue_len(conn), 2);
+
+    ret = xmpp_conn_send_queue_drop_element(conn, XMPP_QUEUE_YOUNGEST);
+    COMPARE("baan", ret);
+    xmpp_free(ctx, ret);
+    ENSURE_EQ(xmpp_conn_send_queue_len(conn), 1);
+
+    ret = xmpp_conn_send_queue_drop_element(conn, XMPP_QUEUE_YOUNGEST);
+    COMPARE("baz", ret);
+    xmpp_free(ctx, ret);
+    ENSURE_EQ(xmpp_conn_send_queue_len(conn), 0);
+
+    conn->state = state;
+
+    xmpp_conn_release(conn);
+    xmpp_ctx_free(ctx);
+    xmpp_shutdown();
+
+    return 0;
+}

--- a/tests/test_send_queue.c
+++ b/tests/test_send_queue.c
@@ -24,6 +24,7 @@ int main()
     xmpp_conn_t *conn;
     xmpp_log_t *log;
     xmpp_conn_state_t state;
+    xmpp_sm_state_t *sm_state;
     char *ret;
 
     unsigned int n;
@@ -32,6 +33,11 @@ int main()
     log = xmpp_get_default_logger(XMPP_LEVEL_DEBUG);
     ctx = xmpp_ctx_new(NULL, log);
     conn = xmpp_conn_new(ctx);
+    sm_state = strophe_alloc(ctx, sizeof(*sm_state));
+    memset(sm_state, 0, sizeof(*sm_state));
+    sm_state->ctx = ctx;
+
+    xmpp_conn_set_sm_state(conn, sm_state);
 
     ENSURE_EQ(xmpp_conn_send_queue_len(conn), 0);
 
@@ -50,7 +56,7 @@ int main()
     xmpp_send_raw(conn, "baan", 4);
     ENSURE_EQ(xmpp_conn_send_queue_len(conn), 4);
 
-    conn->send_queue_head->written = 1;
+    conn->send_queue_head->wip = 1;
     ENSURE_EQ(xmpp_conn_send_queue_len(conn), 3);
 
     ret = xmpp_conn_send_queue_drop_element(conn, XMPP_QUEUE_OLDEST);
@@ -58,7 +64,7 @@ int main()
     xmpp_free(ctx, ret);
     ENSURE_EQ(xmpp_conn_send_queue_len(conn), 2);
 
-    conn->send_queue_head->written = 0;
+    conn->send_queue_head->wip = 0;
     ENSURE_EQ(xmpp_conn_send_queue_len(conn), 3);
 
     ret = xmpp_conn_send_queue_drop_element(conn, XMPP_QUEUE_OLDEST);


### PR DESCRIPTION
This PR started off by adding send-queue management API's

As Stream Management (SM) support as defined in XEP-0198 was also requested and those features are tightly coupled, those topics had to be handled at the same time.

In the current state this PR implements the complete XEP-0198 and adds 5 new API functions and one new feature flag.

SM is enabled by default, and can be disabled by passing the `XMPP_CONN_FLAG_DISABLE_SM` to `xmpp_conn_set_flags()`.

The internal SM state can be retrieved by calling `xmpp_conn_get_sm_state()`. This can only be done when the connection is disconnected.

The SM state can be put into a newly created connection object by calling `xmpp_conn_set_sm_state()`.

In case the user grabbed the SM state but has to dispose of it without setting it into a connection object, the function `xmpp_free_sm_state()` is provided.

Independent of the SM state two send-queue management API's have been added.

By calling `xmpp_conn_send_queue_len()` the number of user-created stanzas that still sit in the send-queue can be determined.

To remove an element from the send-queue, the function `xmpp_conn_send_queue_drop_element()` is provided. It can remove elements from the front of the queue (oldest) or from the back (youngest). The function returns the rendered stanza back to the user who can then decide what to do with it.

One use-case would be to be able to handle connection drops w/o loosing stanzas.

Therefor the user has to do the following after the disconnect event happened:
1. retrieve the SM state
2. check whether there are still user stanza's in the queue, if yes retrieve them via `xmpp_conn_send_queue_drop_element(oldest)` and store them in the same order
3. drop the old & create a fresh connection object
4. re-configure the connection object as initially done
5. restore the SM state
6. re-connect to the server
7. re-send the stanzas retrieved in step 2 via e.g. `xmpp_send_raw()`

