### PR TITLE
add xmpp_stanza_get_child_by_path()

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,7 @@
 0.12.0
 	- Add code coverage support
+	- New API:
+		- xmpp_stanza_get_child_by_path()
 
 0.11.0
 	- SASL EXTERNAL support (XEP-0178)

--- a/strophe.h
+++ b/strophe.h
@@ -406,6 +406,9 @@ xmpp_stanza_t *xmpp_stanza_get_child_by_ns(xmpp_stanza_t *stanza,
 xmpp_stanza_t *xmpp_stanza_get_child_by_name_and_ns(xmpp_stanza_t *stanza,
                                                     const char *name,
                                                     const char *ns);
+/* helper macro for names with a namespace */
+#define XMPP_STANZA_NAME_IN_NS(name, ns) name "[@ns='" ns "']"
+xmpp_stanza_t *xmpp_stanza_get_child_by_path(xmpp_stanza_t *stanza, ...);
 xmpp_stanza_t *xmpp_stanza_get_next(xmpp_stanza_t *stanza);
 int xmpp_stanza_add_child(xmpp_stanza_t *stanza, xmpp_stanza_t *child);
 int xmpp_stanza_add_child_ex(xmpp_stanza_t *stanza,


### PR DESCRIPTION
... to provide an easier way to find long paths.

After looking at some code in profanity-im/profanity#1605 I thought this
could help to make libstrophe-user code easier to write (and read).

Initially it started off as `xmpp_stanza_get_child_by_xpath()` but then
I was annoyed when it came to handling all those potential corner cases
like e.g. escaping URL's in the ns ... so here we go with a
vararg approach :)

Signed-off-by: Steffen Jaeckel <jaeckel-floss@eyet-services.de>