### PR TITLE
Improve support for the glib gMainLoop

### DIFF
--- a/src/conn.c
+++ b/src/conn.c
@@ -241,6 +241,19 @@ void xmpp_conn_set_keepalive(xmpp_conn_t *conn, int timeout, int interval)
     }
 }
 
+/** Get the socket of a connection object
+ *
+ *  @param conn a Strophe connection object
+ *
+ *  @return the socket of the connection
+ *
+ *  @ingroup Connections
+ */
+int xmpp_conn_get_socket(xmpp_conn_t *conn)
+{
+    return conn->sock;
+}
+
 /** Release a Strophe connection object.
  *  Decrement the reference count by one for a connection, freeing the
  *  connection object if the count reaches 0.

--- a/strophe.h
+++ b/strophe.h
@@ -17,6 +17,7 @@
 #define __LIBSTROPHE_STROPHE_H__
 
 #include <stddef.h> /* size_t */
+#include <stdint.h> /* uint64_t */
 
 #ifdef __cplusplus
 extern "C" {
@@ -487,6 +488,9 @@ void xmpp_run_once(xmpp_ctx_t *ctx, unsigned long timeout);
 void xmpp_run(xmpp_ctx_t *ctx);
 void xmpp_stop(xmpp_ctx_t *ctx);
 void xmpp_ctx_set_timeout(xmpp_ctx_t *ctx, unsigned long timeout);
+int xmpp_run_send(xmpp_ctx_t *ctx);
+void xmpp_run_recv(xmpp_ctx_t *ctx, xmpp_conn_t *conn);
+uint64_t xmpp_run_timers(xmpp_ctx_t *ctx);
 
 /* TLS certificates */
 

--- a/strophe.h
+++ b/strophe.h
@@ -295,6 +295,7 @@ xmpp_ctx_t *xmpp_conn_get_context(xmpp_conn_t *conn);
 void xmpp_conn_disable_tls(xmpp_conn_t *conn);
 int xmpp_conn_is_secured(xmpp_conn_t *conn);
 void xmpp_conn_set_keepalive(xmpp_conn_t *conn, int timeout, int interval);
+int xmpp_conn_get_socket(xmpp_conn_t *conn);
 int xmpp_conn_is_connecting(xmpp_conn_t *conn);
 int xmpp_conn_is_connected(xmpp_conn_t *conn);
 int xmpp_conn_is_disconnected(xmpp_conn_t *conn);


### PR DESCRIPTION
After analyzing the performance problems found in https://github.com/profanity-im/profanity/issues/1246 it felt needed to improve the compatibility of libstrophe with the polling approach of the glib main loop. See https://github.com/profanity-im/profanity/pull/1629 too.

By splitting the `xmpp_run_once` into the three smaller functions I'm able to replace the costly `select()` with a polling approach using the gsource of glib, which can wrap around a file descriptor. The timers are also handled by the timeout mechanism built-in into glib. Received data in a connection is individually processed with `xmpp_run_recv()`, while queued data to be send is progressed with `xmpp_run_send()`.

I still need to add some comments and probably rework a bit the code, so I'm marking it as a draft for now.