### PR TITLE
revive removed API's

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -40,6 +40,7 @@ libstrophe_la_SOURCES = \
 	src/conn.c \
 	src/crypto.c \
 	src/ctx.c \
+	src/deprecated.c \
 	src/event.c \
 	src/handler.c \
 	src/hash.c \

--- a/src/auth.c
+++ b/src/auth.c
@@ -540,7 +540,7 @@ static char *_make_scram_init_msg(xmpp_conn_t *conn)
     message_len = strlen(node) + strlen(nonce) + 8 + 1;
     message = strophe_alloc(ctx, message_len);
     if (message) {
-        xmpp_snprintf(message, message_len, "n,,n=%s,r=%s", node, nonce);
+        strophe_snprintf(message, message_len, "n,,n=%s,r=%s", node, nonce);
     }
     strophe_free(ctx, node);
 
@@ -1298,7 +1298,7 @@ int _handle_component_auth(xmpp_conn_t *conn)
     if (digest) {
         /* convert the digest into string representation */
         for (i = 0; i < sizeof(md_value); i++)
-            xmpp_snprintf(digest + i * 2, 3, "%02x", md_value[i]);
+            strophe_snprintf(digest + i * 2, 3, "%02x", md_value[i]);
         digest[2 * sizeof(md_value)] = '\0';
 
         strophe_debug(conn->ctx, "auth", "Digest: %s, len: %d", digest,

--- a/src/common.h
+++ b/src/common.h
@@ -113,6 +113,12 @@ void strophe_debug(const xmpp_ctx_t *ctx,
 void strophe_debug_verbose(
     int level, const xmpp_ctx_t *ctx, const char *area, const char *fmt, ...);
 
+void strophe_log_internal(const xmpp_ctx_t *ctx,
+                          xmpp_log_level_t level,
+                          const char *area,
+                          const char *fmt,
+                          va_list ap);
+
 /** connection **/
 
 /* opaque connection object */

--- a/src/conn.c
+++ b/src/conn.c
@@ -919,7 +919,7 @@ void xmpp_send_raw_string(xmpp_conn_t *conn, const char *fmt, ...)
         return;
 
     va_start(ap, fmt);
-    len = xmpp_vsnprintf(buf, sizeof(buf), fmt, ap);
+    len = strophe_vsnprintf(buf, sizeof(buf), fmt, ap);
     va_end(ap);
 
     if (len >= sizeof(buf)) {
@@ -933,7 +933,7 @@ void xmpp_send_raw_string(xmpp_conn_t *conn, const char *fmt, ...)
             return;
         }
         va_start(ap, fmt);
-        xmpp_vsnprintf(bigbuf, len, fmt, ap);
+        strophe_vsnprintf(bigbuf, len, fmt, ap);
         va_end(ap);
 
         /* len - 1 so we don't send trailing \0 */

--- a/src/crypto.c
+++ b/src/crypto.c
@@ -42,7 +42,7 @@ static char *digest_to_string(const uint8_t *digest, char *s, size_t len)
         return NULL;
 
     for (i = 0; i < SHA1_DIGEST_SIZE; ++i)
-        xmpp_snprintf(s + i * 2, 3, "%02x", digest[i]);
+        strophe_snprintf(s + i * 2, 3, "%02x", digest[i]);
 
     return s;
 }

--- a/src/ctx.c
+++ b/src/ctx.c
@@ -312,6 +312,16 @@ static void _strophe_log(const xmpp_ctx_t *ctx,
         strophe_free(ctx, buf);
 }
 
+/* Dummy trampoline, will be removed when deprecated.c is deleted */
+void strophe_log_internal(const xmpp_ctx_t *ctx,
+                          xmpp_log_level_t level,
+                          const char *area,
+                          const char *fmt,
+                          va_list ap)
+{
+    _strophe_log(ctx, level, area, fmt, ap);
+}
+
 /** Write to the log at the ERROR level.
  *  This is a convenience function for writing to the log at the
  *  ERROR level.  It takes a printf-style format string followed by a

--- a/src/ctx.c
+++ b/src/ctx.c
@@ -283,7 +283,7 @@ static void _strophe_log(const xmpp_ctx_t *ctx,
         return;
 
     va_copy(copy, ap);
-    ret = xmpp_vsnprintf(smbuf, sizeof(smbuf), fmt, ap);
+    ret = strophe_vsnprintf(smbuf, sizeof(smbuf), fmt, ap);
     if (ret >= (int)sizeof(smbuf)) {
         buf = (char *)strophe_alloc(ctx, ret + 1);
         if (!buf) {
@@ -294,7 +294,7 @@ static void _strophe_log(const xmpp_ctx_t *ctx,
             return;
         }
         oldret = ret;
-        ret = xmpp_vsnprintf(buf, ret + 1, fmt, copy);
+        ret = strophe_vsnprintf(buf, ret + 1, fmt, copy);
         if (ret > oldret) {
             strophe_error(ctx, "log", "Unexpected error");
             strophe_free(ctx, buf);

--- a/src/deprecated.c
+++ b/src/deprecated.c
@@ -1,0 +1,233 @@
+/* deprecated.c
+** strophe XMPP client library -- File with deprecated API functions.
+**
+** Copyright (C) 2022 Steffen Jaeckel
+**
+**  This software is provided AS-IS with no warranty, either express
+**  or implied.
+**
+**  This program is dual licensed under the MIT and GPLv3 licenses.
+*/
+
+/** @file
+ *  File with deprecated API functions.
+ */
+
+/** @defgroup Deprecated All deprecated functions
+ *  These functions will be removed in the next release.
+ */
+
+#include "common.h"
+
+/** Allocate memory in a Strophe context.
+ *  All Strophe functions will use this to allocate memory.
+ *
+ *  @param ctx a Strophe context object
+ *  @param size the number of bytes to allocate
+ *
+ *  @return a pointer to the allocated memory or NULL on an error
+ *
+ *  @ingroup Deprecated
+ */
+void *xmpp_alloc(const xmpp_ctx_t *ctx, size_t size)
+{
+    return strophe_alloc(ctx, size);
+}
+
+/** Reallocate memory in a Strophe context.
+ *  All Strophe functions will use this to reallocate memory.
+ *
+ *  @param ctx a Strophe context object
+ *  @param p a pointer to previously allocated memory
+ *  @param size the new size in bytes to allocate
+ *
+ *  @return a pointer to the reallocated memory or NULL on an error
+ *
+ *  @ingroup Deprecated
+ */
+void *xmpp_realloc(const xmpp_ctx_t *ctx, void *p, size_t size)
+{
+    return strophe_realloc(ctx, p, size);
+}
+
+/** implement our own strdup that uses the ctx allocator */
+/** Duplicate a string.
+ *  This function replaces the standard strdup library call with a version
+ *  that uses the Strophe context object's allocator.
+ *
+ *  @param ctx a Strophe context object
+ *  @param s a string
+ *
+ *  @return a newly allocated string with the same data as s or NULL on error
+ *
+ *  @ingroup Deprecated
+ */
+char *xmpp_strdup(const xmpp_ctx_t *ctx, const char *s)
+{
+    return strophe_strdup(ctx, s);
+}
+
+/** Duplicate a string with a maximum length.
+ *  This function replaces the standard strndup library call with a version
+ *  that uses the Strophe context object's allocator.
+ *
+ *  @param ctx a Strophe context object
+ *  @param s a string
+ *  @param len the maximum length of the string to copy
+ *
+ *  @return a newly allocated string that contains at most `len` symbols
+ *             of the original string or NULL on error
+ *
+ *  @ingroup Deprecated
+ */
+char *xmpp_strndup(const xmpp_ctx_t *ctx, const char *s, size_t len)
+{
+    return strophe_strndup(ctx, s, len);
+}
+
+void xmpp_log(const xmpp_ctx_t *ctx,
+              xmpp_log_level_t level,
+              const char *area,
+              const char *fmt,
+              va_list ap)
+{
+    strophe_log_internal(ctx, level, area, fmt, ap);
+}
+
+/** Write to the log at the ERROR level.
+ *  This is a convenience function for writing to the log at the
+ *  ERROR level.  It takes a printf-style format string followed by a
+ *  variable list of arguments for formatting.
+ *
+ *  @param ctx a Strophe context object
+ *  @param area the area to log for
+ *  @param fmt a printf-style format string followed by a variable list of
+ *      arguments to format
+ *
+ *  @ingroup Deprecated
+ */
+void xmpp_error(const xmpp_ctx_t *ctx, const char *area, const char *fmt, ...)
+{
+    va_list ap;
+
+    va_start(ap, fmt);
+    strophe_log_internal(ctx, XMPP_LEVEL_ERROR, area, fmt, ap);
+    va_end(ap);
+}
+
+/** Write to the log at the WARN level.
+ *  This is a convenience function for writing to the log at the WARN level.
+ *  It takes a printf-style format string followed by a variable list of
+ *  arguments for formatting.
+ *
+ *  @param ctx a Strophe context object
+ *  @param area the area to log for
+ *  @param fmt a printf-style format string followed by a variable list of
+ *      arguments to format
+ *
+ *  @ingroup Deprecated
+ */
+void xmpp_warn(const xmpp_ctx_t *ctx, const char *area, const char *fmt, ...)
+{
+    va_list ap;
+
+    va_start(ap, fmt);
+    strophe_log_internal(ctx, XMPP_LEVEL_WARN, area, fmt, ap);
+    va_end(ap);
+}
+
+/** Write to the log at the INFO level.
+ *  This is a convenience function for writing to the log at the INFO level.
+ *  It takes a printf-style format string followed by a variable list of
+ *  arguments for formatting.
+ *
+ *  @param ctx a Strophe context object
+ *  @param area the area to log for
+ *  @param fmt a printf-style format string followed by a variable list of
+ *      arguments to format
+ *
+ *  @ingroup Deprecated
+ */
+void xmpp_info(const xmpp_ctx_t *ctx, const char *area, const char *fmt, ...)
+{
+    va_list ap;
+
+    va_start(ap, fmt);
+    strophe_log_internal(ctx, XMPP_LEVEL_INFO, area, fmt, ap);
+    va_end(ap);
+}
+
+/** Write to the log at the DEBUG level.
+ *  This is a convenience function for writing to the log at the DEBUG level.
+ *  It takes a printf-style format string followed by a variable list of
+ *  arguments for formatting.
+ *
+ *  @param ctx a Strophe context object
+ *  @param area the area to log for
+ *  @param fmt a printf-style format string followed by a variable list of
+ *      arguments to format
+ *
+ *  @ingroup Deprecated
+ */
+void xmpp_debug(const xmpp_ctx_t *ctx, const char *area, const char *fmt, ...)
+{
+    va_list ap;
+
+    va_start(ap, fmt);
+    strophe_log_internal(ctx, XMPP_LEVEL_DEBUG, area, fmt, ap);
+    va_end(ap);
+}
+
+/** Write to the log at the DEBUG level if verbosity is enabled.
+ *  This is a convenience function for writing to the log at the DEBUG level.
+ *  It takes a printf-style format string followed by a variable list of
+ *  arguments for formatting.
+ *
+ *  @param level the verbosity level
+ *  @param ctx a Strophe context object
+ *  @param area the area to log for
+ *  @param fmt a printf-style format string followed by a variable list of
+ *      arguments to format
+ *
+ *  @ingroup Deprecated
+ */
+void xmpp_debug_verbose(
+    int level, const xmpp_ctx_t *ctx, const char *area, const char *fmt, ...)
+{
+    va_list ap;
+
+    if (ctx->verbosity < level)
+        return;
+
+    va_start(ap, fmt);
+    strophe_log_internal(ctx, XMPP_LEVEL_DEBUG, area, fmt, ap);
+    va_end(ap);
+}
+
+/** strtok_r(3) implementation.
+ *  This function has appeared in POSIX.1-2001, but not in C standard.
+ *  For example, visual studio older than 2005 doesn't provide strtok_r()
+ *  nor strtok_s().
+ *
+ *  @ingroup Deprecated
+ */
+char *xmpp_strtok_r(char *s, const char *delim, char **saveptr)
+{
+    return strophe_strtok_r(s, delim, saveptr);
+}
+
+int xmpp_snprintf(char *str, size_t count, const char *fmt, ...)
+{
+    va_list ap;
+    int ret;
+
+    va_start(ap, fmt);
+    ret = strophe_vsnprintf(str, count, fmt, ap);
+    va_end(ap);
+    return ret;
+}
+
+int xmpp_vsnprintf(char *str, size_t count, const char *fmt, va_list arg)
+{
+    return strophe_vsnprintf(str, count, fmt, arg);
+}

--- a/src/resolver.c
+++ b/src/resolver.c
@@ -179,8 +179,8 @@ int resolver_srv_lookup(xmpp_ctx_t *ctx,
     (void)buf;
     (void)len;
 
-    xmpp_snprintf(fulldomain, sizeof(fulldomain), "_%s._%s.%s", service, proto,
-                  domain);
+    strophe_snprintf(fulldomain, sizeof(fulldomain), "_%s._%s.%s", service,
+                     proto, domain);
 
     *srv_rr_list = NULL;
 
@@ -715,8 +715,8 @@ static int resolver_win32_srv_lookup(xmpp_ctx_t *ctx,
                         rr->port = current->Data.Srv.wPort;
                         rr->priority = current->Data.Srv.wPriority;
                         rr->weight = current->Data.Srv.wWeight;
-                        xmpp_snprintf(rr->target, sizeof(rr->target), "%s",
-                                      current->Data.Srv.pNameTarget);
+                        strophe_snprintf(rr->target, sizeof(rr->target), "%s",
+                                         current->Data.Srv.pNameTarget);
                         *srv_rr_list = rr;
                     }
                     current = current->pNext;

--- a/src/sasl.c
+++ b/src/sasl.c
@@ -440,9 +440,9 @@ char *sasl_scram(xmpp_ctx_t *ctx,
         goto out_auth;
     }
 
-    xmpp_snprintf(response, response_len, "c=biws,%s", r);
-    xmpp_snprintf(auth, auth_len, "%s,%s,%s", first_bare + 3, challenge,
-                  response);
+    strophe_snprintf(response, response_len, "c=biws,%s", r);
+    strophe_snprintf(auth, auth_len, "%s,%s,%s", first_bare + 3, challenge,
+                     response);
 
     SCRAM_ClientKey(alg, (uint8_t *)password, strlen(password), (uint8_t *)sval,
                     sval_len, (uint32_t)ival, key);

--- a/src/snprintf.c
+++ b/src/snprintf.c
@@ -61,7 +61,7 @@
 
 /* JAM: we don't need this - #include "config.h" */
 
-/* JAM: changed declarations to xmpp_snprintf and xmpp_vsnprintf to
+/* JAM: changed declarations to strophe_snprintf and strophe_vsnprintf to
    avoid namespace collision. */
 
 #include "snprintf.h"
@@ -722,7 +722,7 @@ int strophe_snprintf(char *str, size_t count, const char *fmt, ...)
     int total;
 
     VA_START(fmt);
-    total = xmpp_vsnprintf(str, count, fmt, ap);
+    total = strophe_vsnprintf(str, count, fmt, ap);
     VA_END;
     return total;
 }

--- a/src/snprintf.h
+++ b/src/snprintf.h
@@ -20,16 +20,14 @@
 #endif
 
 #ifdef HAVE_SNPRINTF
-#define xmpp_snprintf snprintf
+#define strophe_snprintf snprintf
 #else
-#define xmpp_snprintf strophe_snprintf
 int strophe_snprintf(char *str, size_t count, const char *fmt, ...);
 #endif
 
 #ifdef HAVE_VSNPRINTF
-#define xmpp_vsnprintf vsnprintf
+#define strophe_vsnprintf vsnprintf
 #else
-#define xmpp_vsnprintf strophe_vsnprintf
 int strophe_vsnprintf(char *str, size_t count, const char *fmt, va_list arg);
 #endif
 

--- a/src/sock.c
+++ b/src/sock.c
@@ -76,7 +76,7 @@ sock_t sock_connect(const char *host, unsigned short port)
     struct addrinfo *res, *ainfo, hints;
     int err;
 
-    xmpp_snprintf(service, 6, "%u", port);
+    strophe_snprintf(service, 6, "%u", port);
 
     memset(&hints, 0, sizeof(struct addrinfo));
     hints.ai_family = AF_UNSPEC;

--- a/src/stanza.c
+++ b/src/stanza.c
@@ -336,7 +336,7 @@ _render_stanza_recursive(xmpp_stanza_t *stanza, char *buf, size_t buflen)
         tmp = _escape_xml(stanza->ctx, stanza->data);
         if (tmp == NULL)
             return XMPP_EMEM;
-        ret = xmpp_snprintf(ptr, left, "%s", tmp);
+        ret = strophe_snprintf(ptr, left, "%s", tmp);
         strophe_free(stanza->ctx, tmp);
         if (ret < 0)
             return XMPP_EMEM;
@@ -346,7 +346,7 @@ _render_stanza_recursive(xmpp_stanza_t *stanza, char *buf, size_t buflen)
             return XMPP_EINVOP;
 
         /* write beginning of tag and attributes */
-        ret = xmpp_snprintf(ptr, left, "<%s", stanza->data);
+        ret = strophe_snprintf(ptr, left, "<%s", stanza->data);
         if (ret < 0)
             return XMPP_EMEM;
         _render_update(&written, buflen, ret, &left, &ptr);
@@ -374,7 +374,7 @@ _render_stanza_recursive(xmpp_stanza_t *stanza, char *buf, size_t buflen)
                     hash_iter_release(iter);
                     return XMPP_EMEM;
                 }
-                ret = xmpp_snprintf(ptr, left, " %s=\"%s\"", key, tmp);
+                ret = strophe_snprintf(ptr, left, " %s=\"%s\"", key, tmp);
                 strophe_free(stanza->ctx, tmp);
                 if (ret < 0) {
                     hash_iter_release(iter);
@@ -387,7 +387,7 @@ _render_stanza_recursive(xmpp_stanza_t *stanza, char *buf, size_t buflen)
 
         if (!stanza->children) {
             /* write end if singleton tag */
-            ret = xmpp_snprintf(ptr, left, "/>");
+            ret = strophe_snprintf(ptr, left, "/>");
             if (ret < 0)
                 return XMPP_EMEM;
             _render_update(&written, buflen, ret, &left, &ptr);
@@ -395,7 +395,7 @@ _render_stanza_recursive(xmpp_stanza_t *stanza, char *buf, size_t buflen)
             /* this stanza has child stanzas */
 
             /* write end of start tag */
-            ret = xmpp_snprintf(ptr, left, ">");
+            ret = strophe_snprintf(ptr, left, ">");
             if (ret < 0)
                 return XMPP_EMEM;
             _render_update(&written, buflen, ret, &left, &ptr);
@@ -413,7 +413,7 @@ _render_stanza_recursive(xmpp_stanza_t *stanza, char *buf, size_t buflen)
             }
 
             /* write end tag */
-            ret = xmpp_snprintf(ptr, left, "</%s>", stanza->data);
+            ret = strophe_snprintf(ptr, left, "</%s>", stanza->data);
             if (ret < 0)
                 return XMPP_EMEM;
 

--- a/src/tls_gnutls.c
+++ b/src/tls_gnutls.c
@@ -214,7 +214,7 @@ static xmpp_tlscert_t *_x509_to_tlscert(xmpp_ctx_t *ctx, gnutls_x509_crt_t cert)
     hex_encode(buf, smallbuf, size);
     tlscert->elements[XMPP_CERT_FINGERPRINT_SHA256] = strophe_strdup(ctx, buf);
 
-    xmpp_snprintf(buf, sizeof(buf), "%d", gnutls_x509_crt_get_version(cert));
+    strophe_snprintf(buf, sizeof(buf), "%d", gnutls_x509_crt_get_version(cert));
     tlscert->elements[XMPP_CERT_VERSION] = strophe_strdup(ctx, buf);
 
     algo = gnutls_x509_crt_get_pk_algorithm(cert, NULL);

--- a/src/tls_openssl.c
+++ b/src/tls_openssl.c
@@ -433,7 +433,7 @@ static xmpp_tlscert_t *_x509_to_tlscert(xmpp_ctx_t *ctx, X509 *cert)
     tlscert->elements[XMPP_CERT_FINGERPRINT_SHA256] =
         _get_fingerprint(ctx, cert, XMPP_CERT_FINGERPRINT_SHA256);
 
-    xmpp_snprintf(buf, sizeof(buf), "%ld", X509_get_version(cert) + 1);
+    strophe_snprintf(buf, sizeof(buf), "%ld", X509_get_version(cert) + 1);
     tlscert->elements[XMPP_CERT_VERSION] = strophe_strdup(ctx, buf);
 
     tlscert->elements[XMPP_CERT_KEYALG] = _get_alg(ctx, cert, XMPP_CERT_KEYALG);

--- a/strophe.h
+++ b/strophe.h
@@ -587,6 +587,49 @@ void xmpp_rand_bytes(xmpp_rand_t *rand, unsigned char *output, size_t len);
  */
 void xmpp_rand_nonce(xmpp_rand_t *rand, char *output, size_t len);
 
+/**
+ * Formerly "private but exported" functions made public for now to announce
+ * deprecation */
+#include <stdarg.h>
+
+#if defined(__GNUC__) && (__GNUC__ * 100 + __GNUC_MINOR__ >= 405)
+#define XMPP_DEPRECATED \
+    __attribute__((deprecated("Function is internal from next release on")))
+#elif defined(_MSC_VER) && _MSC_VER >= 1500
+#define XMPP_DEPRECATED \
+    __declspec(deprecated("Function is internal from next release on"))
+#else
+#define XMPP_DEPRECATED
+#endif
+
+XMPP_DEPRECATED void *xmpp_alloc(const xmpp_ctx_t *ctx, size_t size);
+XMPP_DEPRECATED void *xmpp_realloc(const xmpp_ctx_t *ctx, void *p, size_t size);
+XMPP_DEPRECATED char *xmpp_strdup(const xmpp_ctx_t *ctx, const char *s);
+XMPP_DEPRECATED char *
+xmpp_strndup(const xmpp_ctx_t *ctx, const char *s, size_t len);
+
+XMPP_DEPRECATED char *xmpp_strtok_r(char *s, const char *delim, char **saveptr);
+XMPP_DEPRECATED int
+xmpp_snprintf(char *str, size_t count, const char *fmt, ...);
+XMPP_DEPRECATED int
+xmpp_vsnprintf(char *str, size_t count, const char *fmt, va_list arg);
+
+XMPP_DEPRECATED void xmpp_log(const xmpp_ctx_t *ctx,
+                              xmpp_log_level_t level,
+                              const char *area,
+                              const char *fmt,
+                              va_list ap);
+XMPP_DEPRECATED void
+xmpp_error(const xmpp_ctx_t *ctx, const char *area, const char *fmt, ...);
+XMPP_DEPRECATED void
+xmpp_warn(const xmpp_ctx_t *ctx, const char *area, const char *fmt, ...);
+XMPP_DEPRECATED void
+xmpp_info(const xmpp_ctx_t *ctx, const char *area, const char *fmt, ...);
+XMPP_DEPRECATED void
+xmpp_debug(const xmpp_ctx_t *ctx, const char *area, const char *fmt, ...);
+XMPP_DEPRECATED void xmpp_debug_verbose(
+    int level, const xmpp_ctx_t *ctx, const char *area, const char *fmt, ...);
+
 #ifdef __cplusplus
 }
 #endif

--- a/tests/test_rand.c
+++ b/tests/test_rand.c
@@ -35,7 +35,7 @@ void strophe_free(const xmpp_ctx_t *ctx, void *p)
 }
 
 #ifndef HAVE_SNPRINTF
-int xmpp_snprintf(char *str, size_t count, const char *fmt, ...)
+int strophe_snprintf(char *str, size_t count, const char *fmt, ...)
 {
     (void)str;
     (void)count;

--- a/tests/test_snprintf.c
+++ b/tests/test_snprintf.c
@@ -37,7 +37,7 @@ int main(void)
 
     for (x = 0; fp_fmt[x] != NULL; x++)
         for (y = 0; fp_nums[y] != 0; y++) {
-            xmpp_snprintf(buf1, sizeof(buf1), fp_fmt[x], fp_nums[y]);
+            strophe_snprintf(buf1, sizeof(buf1), fp_fmt[x], fp_nums[y]);
             sprintf(buf2, fp_fmt[x], fp_nums[y]);
             if (strcmp(buf1, buf2)) {
                 printf("xmpp_snprintf doesn't match Format: "
@@ -50,7 +50,7 @@ int main(void)
 
     for (x = 0; int_fmt[x] != NULL; x++)
         for (y = 0; int_nums[y] != 0; y++) {
-            xmpp_snprintf(buf1, sizeof(buf1), int_fmt[x], int_nums[y]);
+            strophe_snprintf(buf1, sizeof(buf1), int_fmt[x], int_nums[y]);
             sprintf(buf2, int_fmt[x], int_nums[y]);
             if (strcmp(buf1, buf2)) {
                 printf("xmpp_snprintf doesn't match Format: "


### PR DESCRIPTION
In order to do proper deprecation of those API's we re-introduce them
so they can be removed in the next release. This will then also lead to
an ABI bump.