### PR TITLE
Minor fixes

### DIFF
--- a/examples/perf.c
+++ b/examples/perf.c
@@ -32,6 +32,7 @@ static void perf_rand(xmpp_ctx_t *ctx)
     uint64_t t1, t2;
     unsigned int n;
     const size_t alloc_sz = 0x1000u;
+    size_t sz;
     unsigned char *buf = malloc(alloc_sz);
 
     /* pre-heat */
@@ -39,7 +40,7 @@ static void perf_rand(xmpp_ctx_t *ctx)
         xmpp_rand_bytes(rng, buf, n * 10);
     }
 
-    for (size_t sz = 2; sz <= alloc_sz; sz <<= 1) {
+    for (sz = 2; sz <= alloc_sz; sz <<= 1) {
         t2 = 0;
         for (n = 0; n < 1000u; ++n) {
 

--- a/src/handler.c
+++ b/src/handler.c
@@ -694,19 +694,18 @@ void handler_system_delete_all(xmpp_conn_t *conn)
             } else
                 item = item->next;
         }
-        if (head != head_old)
-            key2 = key;
         /* Hash table implementation is not perfect, so we need to find next
            key before dropping current one. Otherwise, we will get access to
            freed memory. */
-        key = hash_iter_next(iter);
+        key2 = hash_iter_next(iter);
         if (head != head_old) {
             /* hash_add() replaces value if the key exists */
             if (head != NULL)
-                hash_add(conn->id_handlers, key2, head);
+                hash_add(conn->id_handlers, key, head);
             else
-                hash_drop(conn->id_handlers, key2);
+                hash_drop(conn->id_handlers, key);
         }
+        key = key2;
     }
     if (iter)
         hash_iter_release(iter);


### PR DESCRIPTION
Fixes for a compile warning:

```
src/handler.c: In function 'handler_system_delete_all':
src/handler.c:706:25: warning: 'key2' may be used uninitialized in this function [-Wmaybe-uninitialized]
                 hash_add(conn->id_handlers, key2, head);
```

and a compile failure when not compiling in C99 mode (default for gcc 4.8.5 on CentOS/RHEL 7):

```
examples/perf.c: In function ‘perf_rand’:
examples/perf.c:42:5: error: ‘for’ loop initial declarations are only allowed in C99 mode
     for (size_t sz = 2; sz <= alloc_sz; sz <<= 1) {
```