### PR TITLE
Add ability to set TCP_KEEPCNT and TCP_USER_TIMEOUT

### DIFF
--- a/examples/basic.c
+++ b/examples/basic.c
@@ -15,10 +15,6 @@
 
 #include <strophe.h>
 
-/* hardcoded TCP keepalive timeout and interval */
-#define KA_TIMEOUT 60
-#define KA_INTERVAL 1
-
 /* define a handler for connection events */
 static void conn_handler(xmpp_conn_t *conn,
                          xmpp_conn_event_t status,

--- a/examples/complex.c
+++ b/examples/complex.c
@@ -15,9 +15,11 @@
 
 #include <strophe.h>
 
-/* hardcoded TCP keepalive timeout and interval */
+/* hardcoded TCP keepalive timeout, interval, count and tcp_user_timeout */
 #define KA_TIMEOUT 60
 #define KA_INTERVAL 1
+#define KA_COUNT 3
+#define USER_TIMEOUT 120
 
 static void print_tlscert(const xmpp_tlscert_t *cert)
 {
@@ -184,7 +186,8 @@ int main(int argc, char **argv)
     xmpp_conn_set_flags(conn, flags);
     /* configure TCP keepalive (optional) */
     if (tcp_keepalive)
-        xmpp_conn_set_keepalive(conn, KA_TIMEOUT, KA_INTERVAL);
+        xmpp_conn_set_keepalive_full(conn, KA_TIMEOUT, KA_INTERVAL, KA_COUNT,
+                                     USER_TIMEOUT);
 
     /* setup authentication information */
     if (cert && key) {

--- a/src/common.h
+++ b/src/common.h
@@ -166,8 +166,10 @@ struct _xmpp_conn_t {
     xmpp_stream_error_t *stream_error;
 
     sock_t sock;
-    int ka_timeout;  /* TCP keepalive timeout */
-    int ka_interval; /* TCP keepalive interval */
+    int ka_timeout;   /* TCP keepalive timeout */
+    int ka_interval;  /* TCP keepalive interval */
+    int ka_count;     /* TCP keepalive count */
+    int user_timeout; /* TCP_USER_TIMEOUT */
 
     tls_t *tls;
     int tls_support;

--- a/src/sock.c
+++ b/src/sock.c
@@ -109,7 +109,8 @@ sock_t sock_connect(const char *host, unsigned short port)
     return sock;
 }
 
-int sock_set_keepalive(sock_t sock, int timeout, int interval)
+int sock_set_keepalive(
+    sock_t sock, int timeout, int interval, int count, int user_timeout)
 {
     int ret;
     int optval = (timeout && interval) ? 1 : 0;
@@ -148,7 +149,26 @@ int sock_set_keepalive(sock_t sock, int timeout, int interval)
         if (ret < 0)
             return ret;
 #endif /* TCP_KEEPINTVL */
+
+#ifdef TCP_KEEPCNT
+        if (count) {
+            ret = setsockopt(sock, IPPROTO_TCP, TCP_KEEPCNT, &count,
+                             sizeof(count));
+            if (ret < 0)
+                return ret;
+        }
+#endif /* TCP_KEEPCNT */
     }
+
+#ifdef TCP_USER_TIMEOUT
+    if (user_timeout) {
+        ret = setsockopt(sock, IPPROTO_TCP, TCP_USER_TIMEOUT, &user_timeout,
+                         sizeof(user_timeout));
+        if (ret < 0)
+            return ret;
+    }
+#endif /* TCP_KEEPCNT */
+
 #endif /* _WIN32 */
 
     return ret;

--- a/src/sock.h
+++ b/src/sock.h
@@ -40,6 +40,7 @@ int sock_write(sock_t sock, const void *buff, size_t len);
 int sock_is_recoverable(int error);
 /* checks for an error after connect, return 0 if connect successful */
 int sock_connect_error(sock_t sock);
-int sock_set_keepalive(sock_t sock, int timeout, int interval);
+int sock_set_keepalive(
+    sock_t sock, int timeout, int interval, int count, int user_timeout);
 
 #endif /* __LIBSTROPHE_SOCK_H__ */

--- a/strophe.h
+++ b/strophe.h
@@ -295,6 +295,8 @@ xmpp_ctx_t *xmpp_conn_get_context(xmpp_conn_t *conn);
 void xmpp_conn_disable_tls(xmpp_conn_t *conn);
 int xmpp_conn_is_secured(xmpp_conn_t *conn);
 void xmpp_conn_set_keepalive(xmpp_conn_t *conn, int timeout, int interval);
+void xmpp_conn_set_keepalive_full(
+    xmpp_conn_t *conn, int timeout, int interval, int count, int user_timeout);
 int xmpp_conn_is_connecting(xmpp_conn_t *conn);
 int xmpp_conn_is_connected(xmpp_conn_t *conn);
 int xmpp_conn_is_disconnected(xmpp_conn_t *conn);


### PR DESCRIPTION
This extends the ability to set keepalive parameters on connections to include TCP_KEEPCNT (count of failed keepalive messages before connection will be terminated) and TCP_USER_TIMEOUT (timeout for pending user data on socket to cause connection termination, available on Linux 2.6.37+)

Added xmpp_conn_set_keepalive_full() to avoid breaking API by adding parameters to xmpp_conn_set_keepalive()