### PR TITLE
Compile tweaks

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -18,6 +18,8 @@ SSL_CFLAGS = @openssl_CFLAGS@
 SSL_LIBS = @openssl_LIBS@
 endif
 
+MINGW_LIBS = @MINGW_LIBS@
+
 RESOLV_CFLAGS = @RESOLV_CFLAGS@
 RESOLV_LIBS = @RESOLV_LIBS@
 
@@ -29,7 +31,7 @@ STROPHE_LIBS = $(COVERAGE_PRE) libstrophe.la $(COVERAGE_POST) $(COVERAGE_LDFLAGS
 lib_LTLIBRARIES = libstrophe.la
 
 libstrophe_la_CFLAGS = $(SSL_CFLAGS) $(STROPHE_FLAGS) $(PARSER_CFLAGS) $(RESOLV_CFLAGS) $(COVERAGE_CFLAGS)
-libstrophe_la_LDFLAGS = $(SSL_LIBS) $(PARSER_LIBS) $(RESOLV_LIBS) -no-undefined
+libstrophe_la_LDFLAGS = $(SSL_LIBS) $(PARSER_LIBS) $(RESOLV_LIBS) $(MINGW_LIBS) -no-undefined
 # Export only public API
 libstrophe_la_LDFLAGS += -export-symbols-regex '^xmpp_' -version-info @VERSION_INFO@
 
@@ -266,8 +268,8 @@ tests_test_xmppaddr_LDFLAGS = -static
 
 format:
 	@echo "   * run clang-format on all sources"
-	@dos2unix -q src/*.[ch] *.h tests/*.[ch] examples/*.c
-	@clang-format -i src/*.[ch] *.h tests/*.[ch] examples/*.c
+	@dos2unix -k -q $(top_srcdir)/src/*.[ch] $(top_srcdir)/*.h $(top_srcdir)/tests/*.[ch] $(top_srcdir)/examples/*.c
+	@clang-format -i $(top_srcdir)/src/*.[ch] $(top_srcdir)/*.h $(top_srcdir)/tests/*.[ch] $(top_srcdir)/examples/*.c
 
 if COVERAGE
 MOSTLYCLEANFILES = src/*.gcno src/*.gcda coverage.info

--- a/Makefile.am
+++ b/Makefile.am
@@ -52,7 +52,6 @@ libstrophe_la_SOURCES = \
 	src/sha1.c \
 	src/sha256.c \
 	src/sha512.c \
-	src/snprintf.c \
 	src/sock.c \
 	src/stanza.c \
 	src/tls.c \
@@ -75,6 +74,10 @@ libstrophe_la_SOURCES += \
 	src/sock.h \
 	src/tls.h \
 	src/util.h
+
+if NEED_SNPRINTF
+libstrophe_la_SOURCES += src/snprintf.c
+endif
 
 if DISABLE_TLS
 libstrophe_la_SOURCES += src/tls_dummy.c

--- a/configure.ac
+++ b/configure.ac
@@ -75,7 +75,7 @@ else
 fi
 
 AC_SEARCH_LIBS([socket], [network socket])
-AC_CHECK_FUNCS([snprintf vsnprintf])
+AC_CHECK_FUNCS([snprintf vsnprintf], [], [have_snprintf=no])
 AC_CHECK_DECLS([va_copy], [], [], [#include <stdarg.h>])
 
 if test "x$enable_tls" != xno -a "x$with_gnutls" == xyes; then
@@ -207,6 +207,7 @@ m4_ifdef([PKG_INSTALLDIR], [PKG_INSTALLDIR],
 
 AM_CONDITIONAL([PARSER_EXPAT], [test x$with_parser != xlibxml2])
 AM_CONDITIONAL([DISABLE_TLS], [test x$enable_tls = xno])
+AM_CONDITIONAL([NEED_SNPRINTF], [test x$have_snprintf = xno])
 AM_CONDITIONAL([TLS_WITH_GNUTLS], [test x$with_gnutls = xyes])
 
 # define while compiling

--- a/configure.ac
+++ b/configure.ac
@@ -25,6 +25,8 @@ AS_CASE([$host_os],
     [*solaris*],   [PLATFORM="solaris"],
     [*android*],   [PLATFORM="android"],
     [*haiku*],     [PLATFORM="haiku"],
+    [*mingw*],     [PLATFORM="win32"
+                    MINGW_LIBS="-lws2_32"],
                    [PLATFORM="nix"])
 
 WARNING_FLAGS="-Wall"
@@ -170,8 +172,10 @@ AS_CASE([$PLATFORM],
     [solaris], [RESOLV_LIBS="-lresolv -lsocket -lnsl"],
     [android], [RESOLV_LIBS=""],
     [haiku],   [RESOLV_LIBS="-lnetwork"],
+    [win32],   [RESOLV_LIBS=""],
                [RESOLV_LIBS="-lresolv"])
 
+if test "x$PLATFORM" != xwin32; then
 LIBS_TMP="${LIBS}"
 LIBS="${RESOLV_LIBS}"
 AC_LINK_IFELSE([AC_LANG_SOURCE([
@@ -190,6 +194,7 @@ AC_LINK_IFELSE([AC_LANG_SOURCE([
     [AC_MSG_ERROR([res_query() not found with LIBS="${LIBS}"])])
 LIBS="${LIBS_TMP}"
 PC_LIBS="${RESOLV_LIBS} ${PC_LIBS}"
+fi
 
 fi
 
@@ -227,6 +232,7 @@ AC_SUBST(COVERAGE_CFLAGS)
 AC_SUBST(COVERAGE_LDFLAGS)
 AC_SUBST(COVERAGE_PRE)
 AC_SUBST(COVERAGE_POST)
+AC_SUBST(MINGW_LIBS)
 AC_SUBST(PARSER_CFLAGS)
 AC_SUBST(PARSER_LIBS)
 AC_SUBST(RESOLV_CFLAGS)


### PR DESCRIPTION
Two minor compile tweaks/fixes:

1. Support (cross)compiling using MinGW-w64

It's not clear how libstrophe is normally compiled for Windows, but these changes make compilation work with mingw-w64 using regular auto* tools

Also fixes 'make format' when using separate source/build directories, and reduces full tree rebuilds by preserving file timestamps when running dos2unix

2. Do not compile/link snprintf.o if it is not needed

Avoids link warning on macos:
```
src/.libs/libstrophe_la-snprintf.o: no symbols
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: file: .libs/libstrophe.a(libstrophe_la-snprintf.o) has no symbols
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: file: .libs/libstrophe.a(libstrophe_la-snprintf.o) has no symbols
```

