### PR TITLE
Add API to register callback to set socket options

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,8 @@
 	- Add code coverage support
 	- New API:
 		- xmpp_stanza_get_child_by_path()
+		- xmpp_conn_set_sockopt_callback()
+		- xmpp_sockopt_cb_keepalive()
 
 0.11.0
 	- SASL EXTERNAL support (XEP-0178)

--- a/examples/basic.c
+++ b/examples/basic.c
@@ -15,10 +15,6 @@
 
 #include <strophe.h>
 
-/* hardcoded TCP keepalive timeout and interval */
-#define KA_TIMEOUT 60
-#define KA_INTERVAL 1
-
 /* define a handler for connection events */
 static void conn_handler(xmpp_conn_t *conn,
                          xmpp_conn_event_t status,
@@ -63,7 +59,7 @@ int main(int argc, char **argv)
     xmpp_ctx_t *ctx;
     xmpp_conn_t *conn;
     xmpp_log_t *log;
-    char *jid = NULL, *password = NULL, *cert = NULL, *key = NULL, *host = NULL;
+    char *jid = NULL, *password = NULL, *host = NULL;
     long flags = 0;
     int i;
     unsigned long port = 0;
@@ -118,9 +114,6 @@ int main(int argc, char **argv)
     xmpp_conn_set_flags(conn, flags);
 
     /* setup authentication information */
-    if (cert && key) {
-        xmpp_conn_set_client_cert(conn, cert, key);
-    }
     if (jid)
         xmpp_conn_set_jid(conn, jid);
     if (password)

--- a/src/common.h
+++ b/src/common.h
@@ -174,6 +174,7 @@ struct _xmpp_conn_t {
     sock_t sock;
     int ka_timeout;  /* TCP keepalive timeout */
     int ka_interval; /* TCP keepalive interval */
+    int ka_count;    /* TCP keepalive count */
 
     tls_t *tls;
     int tls_support;
@@ -233,6 +234,7 @@ struct _xmpp_conn_t {
     xmpp_handlist_t *timed_handlers;
     hash_t *id_handlers;
     xmpp_handlist_t *handlers;
+    xmpp_sockopt_callback sockopt_cb;
 };
 
 void conn_disconnect(xmpp_conn_t *conn);

--- a/src/deprecated.c
+++ b/src/deprecated.c
@@ -231,3 +231,26 @@ int xmpp_vsnprintf(char *str, size_t count, const char *fmt, va_list arg)
 {
     return strophe_vsnprintf(str, count, fmt, arg);
 }
+
+/** Set TCP keepalive parameters
+ *  Turn on TCP keepalive and set timeout and interval. Zero timeout
+ *  disables TCP keepalives. The parameters are applied immediately for
+ *  a non disconnected object. Also, they are applied when the connection
+ *  object connects successfully.
+ *
+ *  @param conn a Strophe connection object
+ *  @param timeout TCP keepalive timeout in seconds
+ *  @param interval TCP keepalive interval in seconds
+ *
+ *  @note this function is deprecated
+ *  @see xmpp_conn_set_sockopt_callback()
+ *
+ *  @ingroup Deprecated
+ */
+void xmpp_conn_set_keepalive(xmpp_conn_t *conn, int timeout, int interval)
+{
+    conn->ka_timeout = timeout;
+    conn->ka_interval = interval;
+    conn->ka_count = 0;
+    xmpp_conn_set_sockopt_callback(conn, xmpp_sockopt_cb_keepalive);
+}

--- a/src/sock.h
+++ b/src/sock.h
@@ -22,6 +22,9 @@
 typedef int sock_t;
 #else
 #include <winsock2.h>
+#include <ws2tcpip.h>
+#include <iphlpapi.h>
+#include <mstcpip.h> /* tcp_keepalive */
 typedef SOCKET sock_t;
 #endif
 
@@ -30,7 +33,7 @@ void sock_shutdown(void);
 
 int sock_error(void);
 
-sock_t sock_connect(const char *host, unsigned short port);
+sock_t sock_connect(xmpp_conn_t *conn, const char *host, unsigned short port);
 int sock_close(sock_t sock);
 
 int sock_set_blocking(sock_t sock);
@@ -40,6 +43,10 @@ int sock_write(sock_t sock, const void *buff, size_t len);
 int sock_is_recoverable(int error);
 /* checks for an error after connect, return 0 if connect successful */
 int sock_connect_error(sock_t sock);
-int sock_set_keepalive(sock_t sock, int timeout, int interval);
+int sock_set_keepalive(sock_t sock,
+                       int timeout,
+                       int interval,
+                       int count,
+                       unsigned int user_timeout);
 
 #endif /* __LIBSTROPHE_SOCK_H__ */


### PR DESCRIPTION
The registered callback function will be called before connect() is called on the socket, allowing tweaking of much more than just keepalive settings.

This deprecates xmpp_conn_set_keepalive(), which will be ignored if it is called for a conn object that already has a sockopt callback set.

Includes helper/example callback function to set default keepalive parameters that some library users may find useful.

This comes from discussion on PR #199.

Examples have been modified to leverage new API:
- bot.c uses included helper callback to set default keepalive values with new --tcp-keepalive option (also reworked option parsing to match basic.c and complex.c)
- complex.c uses custom callback function (but essentially does the same thing)

sock.c is no longer completely standalone from the rest of strophe, as it needed to know about xmpp_conn_t and xmpp_sockopt_callback
We could either:
- live with it? I'm not sure if sock.[ch] are intended to be reusable elsewhere without modification
- move call to callback into conn.c/_conn_connect (I did this originally, but it means callback cannot set socket options before connect() call)
- something else? 
