### PR TITLE
disable ASM in libressl

### DIFF
--- a/travis/before_script.sh
+++ b/travis/before_script.sh
@@ -7,7 +7,7 @@ set -e
 if [ "x$LIBRESSL" = "xtrue" ]; then
     REPO_URL="https://github.com/libressl-portable/portable.git"
     AUTOGEN_CMD="./autogen.sh"
-    CONFIG_CMD="./configure --prefix=$HOME/xssl"
+    CONFIG_CMD="./configure --prefix=$HOME/xssl --disable-asm"
     MAKE_TARGET="install"
 else
     REPO_URL="https://github.com/openssl/openssl.git"


### PR DESCRIPTION
Valgrind spits a false-positive when the AESNI extension is used from ASM.

https://github.com/libressl-portable/portable/issues/760#issuecomment-1175461956

Signed-off-by: Steffen Jaeckel <jaeckel-floss@eyet-services.de>