### PR TITLE
sock: Introduce xmpp_sock_t abstraction

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -198,6 +198,7 @@ struct _xmpp_conn_t {
     int error;
     xmpp_stream_error_t *stream_error;
 
+    xmpp_sock_t *xsock;
     sock_t sock;
     int ka_timeout;  /* TCP keepalive timeout */
     int ka_interval; /* TCP keepalive interval */

--- a/src/resolver.h
+++ b/src/resolver.h
@@ -36,6 +36,12 @@ typedef struct resolver_srv_rr_struc {
 void resolver_initialize(void);
 void resolver_shutdown(void);
 
+resolver_srv_rr_t *resolver_srv_rr_new(xmpp_ctx_t *ctx,
+                                       const char *host,
+                                       unsigned short port,
+                                       unsigned short prio,
+                                       unsigned short weight);
+
 /** Perform lookup for RFC1035 message format.
  *  This function allocates all elements.
  *

--- a/src/sock.h
+++ b/src/sock.h
@@ -20,6 +20,7 @@
 
 #ifndef _WIN32
 typedef int sock_t;
+#define INVALID_SOCKET (-1)
 #else
 #include <winsock2.h>
 #include <ws2tcpip.h>
@@ -28,12 +29,19 @@ typedef int sock_t;
 typedef SOCKET sock_t;
 #endif
 
+typedef struct _xmpp_sock_t xmpp_sock_t;
+
 void sock_initialize(void);
 void sock_shutdown(void);
 
 int sock_error(void);
 
-sock_t sock_connect(xmpp_conn_t *conn, const char *host, unsigned short port);
+xmpp_sock_t *sock_new(xmpp_conn_t *conn,
+                      const char *domain,
+                      const char *host,
+                      unsigned short port);
+void sock_free(xmpp_sock_t *xsock);
+sock_t sock_connect(xmpp_sock_t *xsock);
 int sock_close(sock_t sock);
 
 int sock_set_blocking(sock_t sock);


### PR DESCRIPTION
**This patch needs review and testing!**

libstrophe uses non-blocking sockets and the connect() syscall may return before a TCP connection is established. This doesn't allow to catch all possible errors synchronously and some of the errors are handled in the event handler.

In a scenario with multiple SRV records and/or multiple IP addresses resolution, we need to repeat connection attempt on a failure.

xmpp_sock_t resolves the above problem. It keeps resolved records and addresses to repeat connect attempt asynchronously.