### PR TITLE
Error out if bind is required but not provided

### DIFF
--- a/src/auth.c
+++ b/src/auth.c
@@ -956,10 +956,12 @@ _handle_features_sasl(xmpp_conn_t *conn, xmpp_stanza_t *stanza, void *userdata)
         conn->sm_state->sm_support = 1;
     }
 
-    bind = xmpp_stanza_copy(bind);
-    if (!bind) {
-        disconnect_mem_error(conn);
-        return 0;
+    if (bind) {
+        bind = xmpp_stanza_copy(bind);
+        if (!bind) {
+            disconnect_mem_error(conn);
+            return 0;
+        }
     }
 
     /* we are expecting either <bind/> and <session/> since this is a
@@ -985,6 +987,11 @@ _handle_features_sasl(xmpp_conn_t *conn, xmpp_stanza_t *stanza, void *userdata)
     }
     /* if bind is required, go ahead and start it */
     else if (conn->bind_required) {
+        if (bind == NULL) {
+            strophe_error(conn->ctx, "xmpp",
+                    "Bind is required but not provided.");
+            xmpp_disconnect(conn);
+        }
         /* bind resource */
         _do_bind(conn, bind);
     } else {


### PR DESCRIPTION
Unfortunately not too familar with the code. But wanted to give it a try. If i'm on the right track I will adapt commit message. If I'm taking totally wrong approach I might rather open an issue and close this PR :)

I thought about checking for bind being NULL earlier but then got the impression that it doesn't even matter and we can just error out in the case when it is actually required.

It will thus allow to connect to non rfc6120 compliant servers which could be seen as a downside (without an warning message).

Passing NULL to `xmpp_stanza_release()` is okay I think?