### PR TITLE
Fix wording of licensing terms

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
 libstrophe XMPP client library
 Copyright (C) 2005-2009 Collecta, Inc.
 
-This program is dual licensed under the MIT and GPLv3 licenses.
+This program is dual licensed under the MIT or GPLv3 licenses.
 Please the files MIT-LICENSE.txt and GPL-LICENSE.txt for details.

--- a/README.markdown
+++ b/README.markdown
@@ -5,7 +5,7 @@ libstrophe is a lightweight XMPP client library written in C. It has
 minimal dependencies and is configurable for various environments. It
 runs well on Linux, Unix and Windows based platforms.
 
-libstrophe is dual licensed under MIT and GPLv3.
+libstrophe is dual licensed under MIT or GPLv3.
 
 Build Instructions
 ------------------

--- a/examples/active.c
+++ b/examples/active.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT OR GPL-3.0-only */
 /* active.c
 ** libstrophe XMPP client library -- basic usage example
 **
@@ -6,7 +7,7 @@
 **  This software is provided AS-IS with no warranty, either express
 **  or implied.
 **
-** This program is dual licensed under the MIT and GPLv3 licenses.
+** This program is dual licensed under the MIT or GPLv3 licenses.
 */
 
 /* This example demonstrates basic handler functions by printing out

--- a/examples/basic.c
+++ b/examples/basic.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT OR GPL-3.0-only */
 /* basic.c
 ** libstrophe XMPP client library -- basic usage example
 **
@@ -6,7 +7,7 @@
 **  This software is provided AS-IS with no warranty, either express
 **  or implied.
 **
-** This program is dual licensed under the MIT and GPLv3 licenses.
+** This program is dual licensed under the MIT or GPLv3 licenses.
 */
 
 #include <stdio.h>

--- a/examples/bot.c
+++ b/examples/bot.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT OR GPL-3.0-only */
 /* bot.c
 ** libstrophe XMPP client library -- basic usage example
 **
@@ -6,7 +7,7 @@
 **  This software is provided AS-IS with no warranty, either express
 **  or implied.
 **
-** This program is dual licensed under the MIT and GPLv3 licenses.
+** This program is dual licensed under the MIT or GPLv3 licenses.
 */
 
 /* simple bot example

--- a/examples/complex.c
+++ b/examples/complex.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT OR GPL-3.0-only */
 /* complex.c
 ** libstrophe XMPP client library -- more complex usage example
 **
@@ -6,7 +7,7 @@
 **  This software is provided AS-IS with no warranty, either express
 **  or implied.
 **
-** This program is dual licensed under the MIT and GPLv3 licenses.
+** This program is dual licensed under the MIT or GPLv3 licenses.
 */
 
 #include <stdio.h>

--- a/examples/component.c
+++ b/examples/component.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT OR GPL-3.0-only */
 /* component.c
 ** libstrophe XMPP client library -- external component (XEP-0114) example
 **
@@ -6,7 +7,7 @@
 **  This software is provided AS-IS with no warranty, either express
 **  or implied.
 **
-** This program is dual licensed under the MIT and GPLv3 licenses.
+** This program is dual licensed under the MIT or GPLv3 licenses.
 */
 
 /* This example demonstrates simple connection to a server

--- a/examples/perf.c
+++ b/examples/perf.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT OR GPL-3.0-only */
 /* perf.c
  * strophe XMPP client library -- performance measure
  *
@@ -6,7 +7,7 @@
  *  This software is provided AS-IS with no warranty, either express
  *  or implied.
  *
- *  This program is dual licensed under the MIT and GPLv3 licenses.
+ *  This program is dual licensed under the MIT or GPLv3 licenses.
  */
 
 /** @file

--- a/examples/register.c
+++ b/examples/register.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT OR GPL-3.0-only */
 /* register.c
  * strophe XMPP client library -- In-band registration (XEP-0077)
  *
@@ -6,7 +7,7 @@
  *  This software is provided AS-IS with no warranty, either express
  *  or implied.
  *
- *  This program is dual licensed under the MIT and GPLv3 licenses.
+ *  This program is dual licensed under the MIT or GPLv3 licenses.
  */
 
 /*

--- a/examples/roster.c
+++ b/examples/roster.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT OR GPL-3.0-only */
 /* roster.c
 ** libstrophe XMPP client library -- handler example
 **
@@ -6,7 +7,7 @@
 **  This software is provided AS-IS with no warranty, either express
 **  or implied.
 **
-** This program is dual licensed under the MIT and GPLv3 licenses.
+** This program is dual licensed under the MIT or GPLv3 licenses.
 */
 
 /* This example demonstrates basic handler functions by printing out

--- a/examples/vcard.c
+++ b/examples/vcard.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT OR GPL-3.0-only */
 /* vcard.c
  * strophe XMPP client library -- vCard example
  *
@@ -6,7 +7,7 @@
  *  This software is provided AS-IS with no warranty, either express
  *  or implied.
  *
- *  This program is dual licensed under the MIT and GPLv3 licenses.
+ *  This program is dual licensed under the MIT or GPLv3 licenses.
  */
 
 #include <assert.h>

--- a/src/auth.c
+++ b/src/auth.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT OR GPL-3.0-only */
 /* auth.c
 ** strophe XMPP client library -- auth functions and handlers
 **
@@ -6,7 +7,7 @@
 **  This software is provided AS-IS with no warranty, either express or
 **  implied.
 **
-** This program is dual licensed under the MIT and GPLv3 licenses.
+** This program is dual licensed under the MIT or GPLv3 licenses.
 */
 
 /** @file

--- a/src/common.h
+++ b/src/common.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT OR GPL-3.0-only */
 /* common.h
 ** strophe XMPP client library -- internal common structures
 **
@@ -6,7 +7,7 @@
 **  This software is provided AS-IS with no warranty, either express or
 **  implied.
 **
-**  This program is dual licensed under the MIT and GPLv3 licenses.
+**  This program is dual licensed under the MIT or GPLv3 licenses.
 */
 
 /** @file

--- a/src/conn.c
+++ b/src/conn.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT OR GPL-3.0-only */
 /* conn.c
 ** strophe XMPP client library -- connection object functions
 **
@@ -6,7 +7,7 @@
 **  This software is provided AS-IS with no warranty, either express
 **  or implied.
 **
-**  This program is dual licensed under the MIT and GPLv3 licenses.
+**  This program is dual licensed under the MIT or GPLv3 licenses.
 */
 
 /** @file

--- a/src/crypto.c
+++ b/src/crypto.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT OR GPL-3.0-only */
 /* crypto.c
  * strophe XMPP client library -- public interface for digests, encodings
  *
@@ -6,7 +7,7 @@
  *  This software is provided AS-IS with no warranty, either express
  *  or implied.
  *
- *  This program is dual licensed under the MIT and GPLv3 licenses.
+ *  This program is dual licensed under the MIT or GPLv3 licenses.
  */
 
 /** @file

--- a/src/ctx.c
+++ b/src/ctx.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT OR GPL-3.0-only */
 /* ctx.c
 ** strophe XMPP client library -- run-time context implementation
 **
@@ -6,7 +7,7 @@
 **  This software is provided AS-IS with no warranty, either express
 **  or implied.
 **
-**  This program is dual licensed under the MIT and GPLv3 licenses.
+**  This program is dual licensed under the MIT or GPLv3 licenses.
 */
 
 /** @file

--- a/src/deprecated.c
+++ b/src/deprecated.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT OR GPL-3.0-only */
 /* deprecated.c
 ** strophe XMPP client library -- File with deprecated API functions.
 **
@@ -6,7 +7,7 @@
 **  This software is provided AS-IS with no warranty, either express
 **  or implied.
 **
-**  This program is dual licensed under the MIT and GPLv3 licenses.
+**  This program is dual licensed under the MIT or GPLv3 licenses.
 */
 
 /** @file

--- a/src/event.c
+++ b/src/event.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT OR GPL-3.0-only */
 /* event.c
 ** strophe XMPP client library -- event loop and management
 **
@@ -6,7 +7,7 @@
 **  This software is provided AS-IS with no warranty, either express
 **  or implied.
 **
-** This program is dual licensed under the MIT and GPLv3 licenses.
+** This program is dual licensed under the MIT or GPLv3 licenses.
 */
 
 /** @file

--- a/src/handler.c
+++ b/src/handler.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT OR GPL-3.0-only */
 /* handler.c
 ** strophe XMPP client library -- event handler management
 **
@@ -6,7 +7,7 @@
 **  This software is provided AS-IS with no warranty, either express
 **  or implied.
 **
-**  This program is dual licensed under the MIT and GPLv3 licenses.
+**  This program is dual licensed under the MIT or GPLv3 licenses.
 */
 
 /** @file

--- a/src/hash.c
+++ b/src/hash.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT OR GPL-3.0-only */
 /* hash.c
 ** strophe XMPP client library -- hash table implementation
 **
@@ -6,7 +7,7 @@
 **  This software is provided AS-IS with no warranty, either express
 **  or implied.
 **
-**  This program is dual licensed under the MIT and GPLv3 licenses.
+**  This program is dual licensed under the MIT or GPLv3 licenses.
 */
 
 /** @file

--- a/src/hash.h
+++ b/src/hash.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT OR GPL-3.0-only */
 /* hash.h
 ** strophe XMPP client library -- hash table interface
 **
@@ -6,7 +7,7 @@
 **  This software is provided AS-IS with no warranty, either express
 **  or implied.
 **
-**  This program is dual licensed under the MIT and GPLv3 licenses.
+**  This program is dual licensed under the MIT or GPLv3 licenses.
 */
 
 /** @file

--- a/src/jid.c
+++ b/src/jid.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT OR GPL-3.0-only */
 /* jid.c
 ** strophe XMPP client library -- helper functions for parsing JIDs
 **
@@ -6,7 +7,7 @@
 **  This software is provided AS-IS with no warranty, either express
 **  or implied.
 **
-**  This program is dual licensed under the MIT and GPLv3 licenses.
+**  This program is dual licensed under the MIT or GPLv3 licenses.
 */
 
 /** @file

--- a/src/ostypes.h
+++ b/src/ostypes.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT OR GPL-3.0-only */
 /* ostypes.h
 ** strophe XMPP client library -- type definitions for platforms
 **     without stdint.h
@@ -7,7 +8,7 @@
 **  This software is provided AS-IS with no warranty, either express
 **  or implied.
 **
-**  This program is dual licensed under the MIT and GPLv3 licenses.
+**  This program is dual licensed under the MIT or GPLv3 licenses.
 */
 
 /** @file

--- a/src/parser.h
+++ b/src/parser.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT OR GPL-3.0-only */
 /* parser.h
 ** strophe XMPP client library -- parser structures and functions
 **
@@ -6,7 +7,7 @@
 **  This software is provided AS-IS with no warranty, either express or
 **  implied.
 **
-**  This program is dual licensed under the MIT and GPLv3 licenses.
+**  This program is dual licensed under the MIT or GPLv3 licenses.
 */
 
 /** @file

--- a/src/parser_expat.c
+++ b/src/parser_expat.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT OR GPL-3.0-only */
 /* parser.c
 ** strophe XMPP client library -- xml parser handlers and utility functions
 **
@@ -6,7 +7,7 @@
 **  This software is provided AS-IS with no warranty, either express
 **  or implied.
 **
-**  This program is dual licensed under the MIT and GPLv3 licenses.
+**  This program is dual licensed under the MIT or GPLv3 licenses.
 */
 
 /** @file

--- a/src/parser_libxml2.c
+++ b/src/parser_libxml2.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT OR GPL-3.0-only */
 /* parser.c
 ** strophe XMPP client library -- xml parser handlers and utility functions
 **
@@ -6,7 +7,7 @@
 **  This software is provided AS-IS with no warranty, either express
 **  or implied.
 **
-**  This program is dual licensed under the MIT and GPLv3 licenses.
+**  This program is dual licensed under the MIT or GPLv3 licenses.
 */
 
 /** @file

--- a/src/rand.c
+++ b/src/rand.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT OR GPL-3.0-only */
 /* rand.c
  * strophe XMPP client library -- pseudo-random number generator
  *
@@ -6,7 +7,7 @@
  *  This software is provided AS-IS with no warranty, either express
  *  or implied.
  *
- *  This program is dual licensed under the MIT and GPLv3 licenses.
+ *  This program is dual licensed under the MIT or GPLv3 licenses.
  */
 
 /** @file

--- a/src/resolver.c
+++ b/src/resolver.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT OR GPL-3.0-only */
 /* resolver.c
  * strophe XMPP client library -- DNS resolver
  *
@@ -6,7 +7,7 @@
  *  This software is provided AS-IS with no warranty, either express
  *  or implied.
  *
- *  This program is dual licensed under the MIT and GPLv3 licenses.
+ *  This program is dual licensed under the MIT or GPLv3 licenses.
  */
 
 /** @file

--- a/src/resolver.h
+++ b/src/resolver.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT OR GPL-3.0-only */
 /* resolver.h
  * strophe XMPP client library -- DNS resolver
  *
@@ -6,7 +7,7 @@
  *  This software is provided AS-IS with no warranty, either express
  *  or implied.
  *
- *  This program is dual licensed under the MIT and GPLv3 licenses.
+ *  This program is dual licensed under the MIT or GPLv3 licenses.
  */
 
 /** @file

--- a/src/sasl.c
+++ b/src/sasl.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT OR GPL-3.0-only */
 /* sasl.c
 ** strophe XMPP client library -- SASL authentication helpers
 **
@@ -6,7 +7,7 @@
 **  This software is provided AS-IS with no warranty, either express
 **  or implied.
 **
-**  This program is dual licensed under the MIT and GPLv3 licenses.
+**  This program is dual licensed under the MIT or GPLv3 licenses.
 */
 
 /** @file

--- a/src/sasl.h
+++ b/src/sasl.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT OR GPL-3.0-only */
 /* sasl.h
 ** strophe XMPP client library -- SASL authentication helpers
 **
@@ -6,7 +7,7 @@
 **  This software is provided AS-IS with no warranty, either express
 **  or implied.
 **
-**  This program is dual licensed under the MIT and GPLv3 licenses.
+**  This program is dual licensed under the MIT or GPLv3 licenses.
 */
 
 /** @file

--- a/src/scram.c
+++ b/src/scram.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT OR GPL-3.0-only */
 /* scram.c
  * strophe XMPP client library
  *
@@ -9,7 +10,7 @@
  *  This software is provided AS-IS with no warranty, either express
  *  or implied.
  *
- *  This program is dual licensed under the MIT and GPLv3 licenses.
+ *  This program is dual licensed under the MIT or GPLv3 licenses.
  */
 
 /** @file

--- a/src/scram.h
+++ b/src/scram.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT OR GPL-3.0-only */
 /* scram.h
  * strophe XMPP client library -- SCRAM helper functions
  *
@@ -6,7 +7,7 @@
  *  This software is provided AS-IS with no warranty, either express
  *  or implied.
  *
- *  This program is dual licensed under the MIT and GPLv3 licenses.
+ *  This program is dual licensed under the MIT or GPLv3 licenses.
  */
 
 /** @file

--- a/src/sock.c
+++ b/src/sock.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT OR GPL-3.0-only */
 /* sock.c
 ** strophe XMPP client library -- socket abstraction implementation
 **
@@ -6,7 +7,7 @@
 **  This software is provided AS-IS with no warranty, either express
 **  or implied.
 **
-** This program is dual licensed under the MIT and GPLv3 licenses.
+** This program is dual licensed under the MIT or GPLv3 licenses.
 */
 
 /** @file

--- a/src/sock.h
+++ b/src/sock.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT OR GPL-3.0-only */
 /* sock.h
 ** strophe XMPP client library -- socket abstraction header
 **
@@ -6,7 +7,7 @@
 **  This software is provided AS-IS with no warranty, either express
 **  or implied.
 **
-**  This program is dual licensed under the MIT and GPLv3 licenses.
+**  This program is dual licensed under the MIT or GPLv3 licenses.
 */
 
 /** @file

--- a/src/stanza.c
+++ b/src/stanza.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT OR GPL-3.0-only */
 /* stanza.c
 ** strophe XMPP client library -- XMPP stanza object and utilities
 **
@@ -6,7 +7,7 @@
 **  This software is provided AS-IS with no warranty, either express
 **  or implied.
 **
-**  This program is dual licensed under the MIT and GPLv3 licenses.
+**  This program is dual licensed under the MIT or GPLv3 licenses.
 */
 
 /** @file

--- a/src/tls.c
+++ b/src/tls.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT OR GPL-3.0-only */
 /* tls.c
 ** strophe XMPP client library -- generic TLS functions
 **
@@ -6,7 +7,7 @@
 **  This software is provided AS-IS with no warranty, either express
 **  or implied.
 **
-**  This program is dual licensed under the MIT and GPLv3 licenses.
+**  This program is dual licensed under the MIT or GPLv3 licenses.
 */
 
 /** @file

--- a/src/tls.h
+++ b/src/tls.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT OR GPL-3.0-only */
 /* tls.h
 ** strophe XMPP client library -- TLS abstraction header
 **
@@ -6,7 +7,7 @@
 **  This software is provided AS-IS with no warranty, either express
 **  or implied.
 **
-**  This program is dual licensed under the MIT and GPLv3 licenses.
+**  This program is dual licensed under the MIT or GPLv3 licenses.
 */
 
 /** @file

--- a/src/tls_dummy.c
+++ b/src/tls_dummy.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT OR GPL-3.0-only */
 /* tls_dummy.c
 ** strophe XMPP client library -- TLS abstraction dummy impl.
 **
@@ -6,7 +7,7 @@
 **  This software is provided AS-IS with no warranty, either express
 **  or implied.
 **
-**  This program is dual licensed under the MIT and GPLv3 licenses.
+**  This program is dual licensed under the MIT or GPLv3 licenses.
 */
 
 /** @file

--- a/src/tls_gnutls.c
+++ b/src/tls_gnutls.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT OR GPL-3.0-only */
 /* tls.c
 ** strophe XMPP client library -- TLS abstraction header
 **
@@ -6,7 +7,7 @@
 **  This software is provided AS-IS with no warranty, either express
 **  or implied.
 **
-**  This program is dual licensed under the MIT and GPLv3 licenses.
+**  This program is dual licensed under the MIT or GPLv3 licenses.
 */
 
 /** @file

--- a/src/tls_openssl.c
+++ b/src/tls_openssl.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT OR GPL-3.0-only */
 /* tls_openssl.c
 ** strophe XMPP client library -- TLS abstraction openssl impl.
 **
@@ -6,7 +7,7 @@
 **  This software is provided AS-IS with no warranty, either express
 **  or implied.
 **
-**  This program is dual licensed under the MIT and GPLv3 licenses.
+**  This program is dual licensed under the MIT or GPLv3 licenses.
 */
 
 /** @file

--- a/src/tls_schannel.c
+++ b/src/tls_schannel.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT OR GPL-3.0-only */
 /* tls_schannel.c
 ** strophe XMPP client library -- TLS abstraction schannel impl.
 **
@@ -6,7 +7,7 @@
 **  This software is provided AS-IS with no warranty, either express
 **  or implied.
 **
-**  This program is dual licensed under the MIT and GPLv3 licenses.
+**  This program is dual licensed under the MIT or GPLv3 licenses.
 */
 
 /** @file

--- a/src/util.c
+++ b/src/util.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT OR GPL-3.0-only */
 /* util.c
 ** strophe XMPP client library -- various utility functions
 **
@@ -6,7 +7,7 @@
 **  This software is provided AS-IS with no warranty, either express
 **  or implied.
 **
-**  This program is dual licensed under the MIT and GPLv3 licenses.
+**  This program is dual licensed under the MIT or GPLv3 licenses.
 */
 
 /** @file

--- a/src/util.h
+++ b/src/util.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT OR GPL-3.0-only */
 /* util.h
 ** strophe XMPP client library -- various utility functions
 **
@@ -6,7 +7,7 @@
 **  This software is provided AS-IS with no warranty, either express
 **  or implied.
 **
-**  This program is dual licensed under the MIT and GPLv3 licenses.
+**  This program is dual licensed under the MIT or GPLv3 licenses.
 */
 
 /** @file

--- a/src/uuid.c
+++ b/src/uuid.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT OR GPL-3.0-only */
 /* uuid.c
  * strophe XMPP client library -- UUID generation
  *
@@ -6,7 +7,7 @@
  *  This software is provided AS-IS with no warranty, either express
  *  or implied.
  *
- *  This program is dual licensed under the MIT and GPLv3 licenses.
+ *  This program is dual licensed under the MIT or GPLv3 licenses.
  */
 
 /** @file

--- a/strophe.h
+++ b/strophe.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT OR GPL-3.0-only */
 /* strophe.h
 ** strophe XMPP client library C API
 **
@@ -6,7 +7,7 @@
 **  This software is provided AS-IS with no warranty, either express or
 **  implied.
 **
-**  This software is dual licensed under the MIT and GPLv3 licenses.
+**  This software is dual licensed under the MIT or GPLv3 licenses.
 */
 
 /** @file

--- a/tests/check_parser.c
+++ b/tests/check_parser.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT OR GPL-3.0-only */
 /* check_parser.h
 ** strophe XMPP client library -- parser tests
 **
@@ -6,7 +7,7 @@
 **  This software is provided AS-IS with no warranty, either express or
 **  implied.
 **
-**  This program is dual licensed under the MIT and GPLv3 licenses.
+**  This program is dual licensed under the MIT or GPLv3 licenses.
 */
 
 #include <stdlib.h>

--- a/tests/res_query_dump.c
+++ b/tests/res_query_dump.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT OR GPL-3.0-only */
 /* res_query_dump.c
  * Simple program to dump res_query(3) response
  *
@@ -6,7 +7,7 @@
  *  This software is provided AS-IS with no warranty, either express
  *  or implied.
  *
- *  This program is dual licensed under the MIT and GPLv3 licenses.
+ *  This program is dual licensed under the MIT or GPLv3 licenses.
  */
 
 /* Linux and OSX:

--- a/tests/test.c
+++ b/tests/test.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT OR GPL-3.0-only */
 /* test.c
  * strophe XMPP client library -- common routines for tests
  *
@@ -6,7 +7,7 @@
  *  This software is provided AS-IS with no warranty, either express
  *  or implied.
  *
- *  This program is dual licensed under the MIT and GPLv3 licenses.
+ *  This program is dual licensed under the MIT or GPLv3 licenses.
  */
 
 #include <assert.h>

--- a/tests/test.h
+++ b/tests/test.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT OR GPL-3.0-only */
 /* test.h
 ** libstrophe XMPP client library -- common routines for tests
 **
@@ -6,7 +7,7 @@
 **  This software is provided AS-IS with no warranty, either express
 **  or implied.
 **
-**  This program is dual licensed under the MIT and GPLv3 licenses.
+**  This program is dual licensed under the MIT or GPLv3 licenses.
 */
 
 #ifndef __LIBSTROPHE_TEST_H__

--- a/tests/test_base64.c
+++ b/tests/test_base64.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT OR GPL-3.0-only */
 /* test_base64.c
 ** libstrophe XMPP client library -- test routines for the base64 codec
 **
@@ -6,7 +7,7 @@
 **  This software is provided AS-IS with no warranty, either express
 **  or implied.
 **
-**  This program is dual licensed under the MIT and GPLv3 licenses.
+**  This program is dual licensed under the MIT or GPLv3 licenses.
 */
 
 #include <assert.h>

--- a/tests/test_ctx.c
+++ b/tests/test_ctx.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT OR GPL-3.0-only */
 /* test_ctx.c
 ** libstrophe XMPP client library -- test routines for the library run-time
 *context
@@ -7,7 +8,7 @@
 **  This software is provided AS-IS with no warranty, either express
 **  or implied.
 **
-**  This program is dual licensed under the MIT and GPLv3 licenses.
+**  This program is dual licensed under the MIT or GPLv3 licenses.
 */
 
 #include <stdio.h>

--- a/tests/test_hash.c
+++ b/tests/test_hash.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT OR GPL-3.0-only */
 /* test_hash.c
 ** libstrophe XMPP client library -- self-test for the hash-table implementation
 **
@@ -6,7 +7,7 @@
 **  This software is provided AS-IS with no warranty, either express
 **  or implied.
 **
-** This program is dual licensed under the MIT and GPLv3 licenses.
+** This program is dual licensed under the MIT or GPLv3 licenses.
 */
 
 #include <stdlib.h>

--- a/tests/test_jid.c
+++ b/tests/test_jid.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT OR GPL-3.0-only */
 /* test_jid.c
 ** libstrophe XMPP client library -- test routines for the jid utils
 **
@@ -6,7 +7,7 @@
 **  This software is provided AS-IS with no warranty, either express
 **  or implied.
 **
-**  This program is dual licensed under the MIT and GPLv3 licenses.
+**  This program is dual licensed under the MIT or GPLv3 licenses.
 */
 
 #include <stdio.h>

--- a/tests/test_md5.c
+++ b/tests/test_md5.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT OR GPL-3.0-only */
 /* test_md5.c
  * strophe XMPP client library -- test vectors for MD5
  *
@@ -6,7 +7,7 @@
  *  This software is provided AS-IS with no warranty, either express
  *  or implied.
  *
- *  This program is dual licensed under the MIT and GPLv3 licenses.
+ *  This program is dual licensed under the MIT or GPLv3 licenses.
  */
 
 /* gcc -o test_md5 -I./src tests/test_md5.c tests/test.c src/md5.c */

--- a/tests/test_rand.c
+++ b/tests/test_rand.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT OR GPL-3.0-only */
 /* check_rand.c
  * strophe XMPP client library -- test vectors for Hash_DRBG
  *
@@ -6,7 +7,7 @@
  *  This software is provided AS-IS with no warranty, either express
  *  or implied.
  *
- *  This program is dual licensed under the MIT and GPLv3 licenses.
+ *  This program is dual licensed under the MIT or GPLv3 licenses.
  */
 
 /* gcc -o test_rand -I./src tests/test_rand.c tests/test.c src/sha1.c */

--- a/tests/test_resolver.c
+++ b/tests/test_resolver.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT OR GPL-3.0-only */
 /* test_resolver.c
  * strophe XMPP client library -- tests for resolver
  *
@@ -6,7 +7,7 @@
  *  This software is provided AS-IS with no warranty, either express
  *  or implied.
  *
- *  This program is dual licensed under the MIT and GPLv3 licenses.
+ *  This program is dual licensed under the MIT or GPLv3 licenses.
  */
 
 #include <assert.h>

--- a/tests/test_sasl.c
+++ b/tests/test_sasl.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT OR GPL-3.0-only */
 /* test_sasl.c
 ** libstrophe XMPP client library -- test routines for the SASL implementation
 **
@@ -6,7 +7,7 @@
 **  This software is provided AS-IS with no warranty, either express
 **  or implied.
 **
-**  This program is dual licensed under the MIT and GPLv3 licenses.
+**  This program is dual licensed under the MIT or GPLv3 licenses.
 */
 
 #include <stdio.h>

--- a/tests/test_scram.c
+++ b/tests/test_scram.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT OR GPL-3.0-only */
 /* test_scram.c
  * strophe XMPP client library -- test vectors for SCRAM-SHA1
  *
@@ -6,7 +7,7 @@
  *  This software is provided AS-IS with no warranty, either express
  *  or implied.
  *
- *  This program is dual licensed under the MIT and GPLv3 licenses.
+ *  This program is dual licensed under the MIT or GPLv3 licenses.
  */
 
 /* gcc -o test_scram -I./src tests/test_scram.c tests/test.c src/sha1.c */

--- a/tests/test_send_queue.c
+++ b/tests/test_send_queue.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT OR GPL-3.0-only */
 /* test_send_queue.c
 ** libstrophe XMPP client library -- test routines for the send queue
 **
@@ -6,7 +7,7 @@
 **  This software is provided AS-IS with no warranty, either express
 **  or implied.
 **
-**  This program is dual licensed under the MIT and GPLv3 licenses.
+**  This program is dual licensed under the MIT or GPLv3 licenses.
 */
 
 #include <assert.h>

--- a/tests/test_sock.c
+++ b/tests/test_sock.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT OR GPL-3.0-only */
 /* test_sock.c
 ** libstrophe XMPP client library -- test routines for the socket abstraction
 **
@@ -6,7 +7,7 @@
 **  This software is provided AS-IS with no warranty, either express
 **  or implied.
 **
-** This program is dual licensed under the MIT and GPLv3 licenses.
+** This program is dual licensed under the MIT or GPLv3 licenses.
 */
 
 #include <stdio.h>

--- a/tests/test_stanza.c
+++ b/tests/test_stanza.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT OR GPL-3.0-only */
 /* test_stanza.c
  * libstrophe XMPP client library -- test routines for stanza functions
  *
@@ -6,7 +7,7 @@
  *  This software is provided AS-IS with no warranty, either express
  *  or implied.
  *
- *  This program is dual licensed under the MIT and GPLv3 licenses.
+ *  This program is dual licensed under the MIT or GPLv3 licenses.
  */
 
 /* gcc -o test_stanza -I./src tests/test_stanza.c -lstrophe */

--- a/tests/test_string.c
+++ b/tests/test_string.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT OR GPL-3.0-only */
 /* test_string.c
  * strophe XMPP client library -- tests for re-implemented string functions
  *
@@ -6,7 +7,7 @@
  *  This software is provided AS-IS with no warranty, either express
  *  or implied.
  *
- *  This program is dual licensed under the MIT and GPLv3 licenses.
+ *  This program is dual licensed under the MIT or GPLv3 licenses.
  */
 
 #include <assert.h>

--- a/tests/test_xmppaddr.c
+++ b/tests/test_xmppaddr.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT OR GPL-3.0-only */
 /* test_xmppaddr.c
 ** libstrophe XMPP client library -- test routines for the xmppaddr
 ** certificate API's
@@ -7,7 +8,7 @@
 **  This software is provided AS-IS with no warranty, either express
 **  or implied.
 **
-**  This program is dual licensed under the MIT and GPLv3 licenses.
+**  This program is dual licensed under the MIT or GPLv3 licenses.
 */
 
 #include <assert.h>


### PR DESCRIPTION
It has been pointed out that the wording of the license of this library is not entirely clear.

The term "dual licensing" usually refers to a licence choice of two licenses "LICENSE1 _or_ LICENSE2.
Instead the license of this library claimed "LICENSE1 _and_ LICENSE2".

After an internal discussion with @metajack and @pasis it was made clear that the initial idea was to dual license the library in the usual way.

This was also made clear by jack on the ML in the past [0]. As of jack, these licensing terms originated from jquery, which also used the 'and' version in the past and has since been corrected [1].

This patch changes the license terms to 'MIT or GPLv3' and also adds SPDX headers [2].

[0] https://groups.google.com/g/libstrophe/c/JkFgr601JQc
[1] https://stackoverflow.com/q/2758409
[2] https://spdx.org