### PR TITLE
Stop reaching into X509_ALGOR

### DIFF
--- a/src/tls_openssl.c
+++ b/src/tls_openssl.c
@@ -412,8 +412,10 @@ _get_alg(const xmpp_ctx_t *ctx, X509 *err_cert, xmpp_cert_element_t el)
         alg_nid = OBJ_obj2nid(err_cert->sig_alg->algorithm);
 #else
         const X509_ALGOR *palg;
+        const ASN1_OBJECT *obj;
         X509_get0_signature(NULL, &palg, err_cert);
-        alg_nid = OBJ_obj2nid(palg->algorithm);
+        X509_ALGOR_get0(&obj, NULL, NULL, palg);
+        alg_nid = OBJ_obj2nid(obj);
 #endif
     } break;
     default:


### PR DESCRIPTION
While the struct is still public in all versions of OpenSSL and its forks, this may well change in the future. Prepare for that case and use the X509_ALGOR_get0() accessor which has been available with this signature since OpenSSL 1.1.