### PR TITLE
Only signal "stream negotiation success" once.

### DIFF
--- a/src/sock.c
+++ b/src/sock.c
@@ -207,7 +207,7 @@ sock_t sock_connect(xmpp_sock_t *xsock)
 {
     struct addrinfo *ainfo;
     sock_t sock;
-    int rc = 0;
+    int rc;
     char buf[64];
 
     do {
@@ -228,6 +228,7 @@ sock_t sock_connect(xmpp_sock_t *xsock)
 
         sock = socket(ainfo->ai_family, ainfo->ai_socktype, ainfo->ai_protocol);
         if (sock != INVALID_SOCKET) {
+            rc = 0;
             if (xsock->conn->sockopt_cb) {
                 /* Don't allow user to overwrite sockfd value. */
                 sock_t sock_copy = sock;


### PR DESCRIPTION
The code-path which checks whether the server requires an "xmpp-session" was untested and therefore the connection-callback handler was triggered twice with the state `XMPP_CONN_CONNECT`. This happened if the server supports stream-management and requires a session.

Reported via https://github.com/profanity-im/profanity/issues/1954

Fixup of c7d410f38b7e51db71eff065c00d3b9d9c895a53