### PR TITLE
Allow serializing SM state

### DIFF
--- a/src/conn.c
+++ b/src/conn.c
@@ -1282,6 +1282,80 @@ xmpp_sm_state_t *xmpp_conn_get_sm_state(xmpp_conn_t *conn)
     return ret;
 }
 
+struct xmpp_sm_serializable_state_t *xmpp_conn_get_sm_serializable_state(xmpp_conn_t *conn)
+{
+    if (!conn->sm_state->sm_support || !conn->sm_state->sm_enabled || !conn->sm_state->can_resume) {
+        return NULL;
+    }
+
+    struct xmpp_sm_serializable_state_t *ser = strophe_alloc(conn->ctx, sizeof(ser));
+    ser->sm_handled_nr = conn->sm_state->sm_handled_nr;
+    ser->sm_sent_nr = conn->sm_state->sm_sent_nr;
+    ser->id = strophe_strdup(conn->ctx, conn->sm_state->id);
+    ser->q_size = 0;
+    size_t capacity = 10;
+    ser->q = strophe_alloc(conn->ctx, capacity * sizeof(*ser->q));
+    xmpp_send_queue_t *peek = conn->sm_state->sm_queue.head;
+    while (peek) {
+        ser->q_size++;
+        if (ser->q_size > capacity) {
+            capacity *= 2;
+            ser->q = strophe_realloc(conn->ctx, ser->q, capacity * sizeof(*ser->q));
+        }
+        ser->q[ser->q_size - 1] = strophe_strdup(conn->ctx, peek->data);
+        peek = peek->next;
+    }
+    return ser;
+}
+
+int xmpp_conn_set_sm_serializable_state(xmpp_conn_t *conn, uint32_t sm_handled_nr, uint32_t sm_sent_nr, char *id, char **q, size_t q_size)
+{
+    /* We can only set the SM state when we're disconnected */
+    if (conn->state != XMPP_STATE_DISCONNECTED) {
+        strophe_error(conn->ctx, "conn",
+                      "SM state can only be set the when we're disconnected");
+        return XMPP_EINVOP;
+    }
+
+    if (conn->sm_state) {
+        strophe_error(conn->ctx, "conn", "SM state is already set!");
+        return XMPP_EINVOP;
+    }
+
+    conn->sm_state = strophe_alloc(conn->ctx, sizeof(*conn->sm_state));
+    if (!conn->sm_state) return XMPP_EMEM;
+    memset(conn->sm_state, 0, sizeof(*conn->sm_state));
+    conn->sm_state->ctx = conn->ctx;
+
+    conn->sm_state->sm_support = 1;
+    conn->sm_state->sm_enabled = 1;
+    conn->sm_state->can_resume = 1;
+    conn->sm_state->resume = 1;
+    conn->sm_state->sm_handled_nr = sm_handled_nr;
+    conn->sm_state->sm_sent_nr = sm_sent_nr;
+    conn->sm_state->id = id;
+
+    for (size_t i = 0; i < q_size; i++) {
+        xmpp_send_queue_t *item = strophe_alloc(conn->ctx, sizeof(*item));
+        if (!item) {
+            reset_sm_state(conn->sm_state);
+            strophe_free(conn->ctx, conn->sm_state);
+            conn->sm_state = NULL;
+            return XMPP_EMEM;
+        }
+
+        item->data = q[i];
+        item->len = strlen(q[i]);
+        item->written = 0;
+        item->wip = 0;
+        item->userdata = NULL;
+        item->owner = XMPP_QUEUE_USER;
+        add_queue_back(&conn->sm_state->sm_queue, item);
+    }
+
+    return XMPP_EOK;
+}
+
 static void _reset_sm_state_for_reconnect(xmpp_conn_t *conn)
 {
     xmpp_sm_state_t *s = conn->sm_state;

--- a/strophe.h
+++ b/strophe.h
@@ -18,6 +18,7 @@
 #define __LIBSTROPHE_STROPHE_H__
 
 #include <stddef.h> /* size_t */
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -182,6 +183,14 @@ xmpp_log_t *xmpp_get_default_logger(xmpp_log_level_t level);
 typedef struct _xmpp_conn_t xmpp_conn_t;
 typedef struct _xmpp_stanza_t xmpp_stanza_t;
 typedef struct _xmpp_sm_t xmpp_sm_state_t;
+
+struct xmpp_sm_serializable_state_t {
+    uint32_t sm_handled_nr;
+    uint32_t sm_sent_nr;
+    char *id;
+    char **q;
+    size_t q_size;
+};
 
 /* connection flags */
 #define XMPP_CONN_FLAG_DISABLE_TLS (1UL << 0)


### PR DESCRIPTION
It is useful in some applications to get a snapshot of the stream management state for storage outside the process, in order to recover from crashes and other things.  The get_sm_state already present is not suitable for this because it returns a live object tied in to the current context and such, and containing much unneeded internal-api data.

Introduce a new get_sm_serializable_state that creates instead a fixed snapshot, handing full memory ownership to the caller, and a dual set_sm_serializable_state which takes in the bare minimum needed values in order to resume and sets up a new sm_state based on these values.