### PR TITLE
conn: Fix cross compilation with mingw

### DIFF
--- a/src/conn.c
+++ b/src/conn.c
@@ -21,7 +21,7 @@
  */
 
 #include <errno.h>
-#ifndef _MSC_VER
+#if !defined(_MSC_VER) && !defined(_WIN32)
 #include <netinet/in.h>
 #endif
 #include <stdarg.h>


### PR DESCRIPTION
Mingw doesn't find netinet/in.h which is not supposed to be used for a windows build. This header is conditionally compiled when _MSC_VER is not defined, however, mingw defines only _WIN32 and not the _MSC_VER.

Add also _WIN32 to the condition, so mingw ignores the header and relies on winsock2.h from common.h->sock.h.

Fixes #265.