### PR TITLE
Fix compile errors on implicit weak-typed function pointer casting starting from C23

### DIFF
--- a/src/handler.c
+++ b/src/handler.c
@@ -318,7 +318,7 @@ static void _timed_handler_delete(xmpp_ctx_t *ctx,
  */
 void xmpp_timed_handler_delete(xmpp_conn_t *conn, xmpp_timed_handler handler)
 {
-    _timed_handler_delete(conn->ctx, &conn->timed_handlers, handler);
+    _timed_handler_delete(conn->ctx, &conn->timed_handlers, (xmpp_void_handler)handler);
 }
 
 static void _id_handler_add(xmpp_conn_t *conn,
@@ -347,7 +347,7 @@ static void _id_handler_add(xmpp_conn_t *conn,
         return;
 
     item->user_handler = user_handler;
-    item->handler = handler;
+    item->handler = (xmpp_void_handler)handler;
     item->userdata = userdata;
     item->enabled = 0;
     item->next = NULL;
@@ -449,7 +449,7 @@ static void _handler_add(xmpp_conn_t *conn,
 
     memset(item, 0, sizeof(*item));
     item->user_handler = user_handler;
-    item->handler = handler;
+    item->handler = (xmpp_void_handler)handler;
     item->userdata = userdata;
 
     if (_dup_string(conn->ctx, ns, &item->u.ns))
@@ -528,7 +528,7 @@ void xmpp_timed_handler_add(xmpp_conn_t *conn,
                             unsigned long period,
                             void *userdata)
 {
-    _timed_handler_add(conn->ctx, &conn->timed_handlers, handler, period,
+    _timed_handler_add(conn->ctx, &conn->timed_handlers, (xmpp_void_handler)handler, period,
                        userdata, 1);
 }
 
@@ -546,7 +546,7 @@ void handler_add_timed(xmpp_conn_t *conn,
                        unsigned long period,
                        void *userdata)
 {
-    _timed_handler_add(conn->ctx, &conn->timed_handlers, handler, period,
+    _timed_handler_add(conn->ctx, &conn->timed_handlers, (xmpp_void_handler)handler, period,
                        userdata, 0);
 }
 
@@ -745,7 +745,7 @@ void xmpp_global_timed_handler_add(xmpp_ctx_t *ctx,
                                    unsigned long period,
                                    void *userdata)
 {
-    _timed_handler_add(ctx, &ctx->timed_handlers, handler, period, userdata, 1);
+    _timed_handler_add(ctx, &ctx->timed_handlers, (xmpp_void_handler)handler, period, userdata, 1);
 }
 
 /** Delete a global timed handler.
@@ -758,5 +758,5 @@ void xmpp_global_timed_handler_add(xmpp_ctx_t *ctx,
 void xmpp_global_timed_handler_delete(xmpp_ctx_t *ctx,
                                       xmpp_global_timed_handler handler)
 {
-    _timed_handler_delete(ctx, &ctx->timed_handlers, handler);
+    _timed_handler_delete(ctx, &ctx->timed_handlers, (xmpp_void_handler)handler);
 }


### PR DESCRIPTION
Since C23, implicit weak-typed function pointer casting has been dropped. This PR fixes those legacy usage to prevent compile errors on newer GCC.

Maybe related downstream issue: https://github.com/NixOS/nixpkgs/issues/475926